### PR TITLE
Add stubbed SSH event handlers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,11 @@ NODE_ENV=${NODE_ENV}
 # See: https://github.com/winstonjs/winston#logging-levels
 # e.g. error, warn, info, http, verbose, debug, silly
 LOG_LEVEL=${LOG_LEVEL}
+
+# The port the SSH service will listen on
+# See https://nodejs.org/api/net.html#serverlistenoptions-callback
+SSH_PORT=${SSH_PORT}
+
+# The hostname the SSH service will listen on
+# See https://nodejs.org/api/net.html#serverlistenoptions-callback
+SSH_HOST=${SSH_HOSTNAME}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@sentry/node": "^6.16.1",
+        "@types/ssh2": "^0.5.50",
         "dotenv": "^10.0.0",
         "logform": "^2.3.2",
+        "ssh2": "^1.5.0",
         "winston": "^3.4.0"
       },
       "devDependencies": {
@@ -2874,14 +2876,30 @@
     "node_modules/@types/node": {
       "version": "17.0.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
-      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
-      "dev": true
+      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg=="
     },
     "node_modules/@types/prettier": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz",
       "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==",
       "dev": true
+    },
+    "node_modules/@types/ssh2": {
+      "version": "0.5.50",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.50.tgz",
+      "integrity": "sha512-Eu/rzX4L+GhWIKEFQbaeWKECdy8VRdIYOqjMlFp+v4v7tBhvcl30m34BZzVALn/dNXvcB6dmcMtspIW7iPOlPg==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2-streams": "*"
+      }
+    },
+    "node_modules/@types/ssh2-streams": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.9.tgz",
+      "integrity": "sha512-I2J9jKqfmvXLR5GomDiCoHrEJ58hAOmFrekfFqmCFd+A6gaEStvWnPykoWUwld1PNg4G5ag1LwdA+Lz1doRJqg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -3339,6 +3357,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
@@ -3574,6 +3600,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -4123,6 +4157,19 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.2.tgz",
+      "integrity": "sha512-/2yieBqvMcRj8McNzkycjW2v3OIUOibBfd2dLEJ0nWts8NobAxwiyw9phVNS6oDL8x8tz9F7uNVFEVpJncQpeA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "nan": "^2.14.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -8382,6 +8429,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "optional": true
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -9324,8 +9377,7 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/saxes": {
       "version": "5.0.1",
@@ -9469,6 +9521,23 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "node_modules/ssh2": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.5.0.tgz",
+      "integrity": "sha512-iUmRkhH9KGeszQwDW7YyyqjsMTf4z+0o48Cp4xOwlY5LjtbIAvyd3fwnsoUZW/hXmTCRA3yt7S/Jb9uVjErVlA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.4",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "0.0.2",
+        "nan": "^2.15.0"
+      }
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -9854,6 +9923,11 @@
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -12545,14 +12619,30 @@
     "@types/node": {
       "version": "17.0.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
-      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
-      "dev": true
+      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg=="
     },
     "@types/prettier": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz",
       "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==",
       "dev": true
+    },
+    "@types/ssh2": {
+      "version": "0.5.50",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.50.tgz",
+      "integrity": "sha512-Eu/rzX4L+GhWIKEFQbaeWKECdy8VRdIYOqjMlFp+v4v7tBhvcl30m34BZzVALn/dNXvcB6dmcMtspIW7iPOlPg==",
+      "requires": {
+        "@types/node": "*",
+        "@types/ssh2-streams": "*"
+      }
+    },
+    "@types/ssh2-streams": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.9.tgz",
+      "integrity": "sha512-I2J9jKqfmvXLR5GomDiCoHrEJ58hAOmFrekfFqmCFd+A6gaEStvWnPykoWUwld1PNg4G5ag1LwdA+Lz1doRJqg==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -12854,6 +12944,14 @@
         "es-abstract": "^1.19.0"
       }
     },
+    "asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "async": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
@@ -13037,6 +13135,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -13463,6 +13569,15 @@
           "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
           "dev": true
         }
+      }
+    },
+    "cpu-features": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.2.tgz",
+      "integrity": "sha512-/2yieBqvMcRj8McNzkycjW2v3OIUOibBfd2dLEJ0nWts8NobAxwiyw9phVNS6oDL8x8tz9F7uNVFEVpJncQpeA==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.14.1"
       }
     },
     "cross-spawn": {
@@ -16652,6 +16767,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "optional": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -17352,8 +17473,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "saxes": {
       "version": "5.0.1",
@@ -17469,6 +17589,17 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "ssh2": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.5.0.tgz",
+      "integrity": "sha512-iUmRkhH9KGeszQwDW7YyyqjsMTf4z+0o48Cp4xOwlY5LjtbIAvyd3fwnsoUZW/hXmTCRA3yt7S/Jb9uVjErVlA==",
+      "requires": {
+        "asn1": "^0.2.4",
+        "bcrypt-pbkdf": "^1.0.2",
+        "cpu-features": "0.0.2",
+        "nan": "^2.15.0"
+      }
     },
     "stack-trace": {
       "version": "0.0.10",
@@ -17758,6 +17889,11 @@
       "requires": {
         "tslib": "^1.8.1"
       }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,10 @@
   },
   "dependencies": {
     "@sentry/node": "^6.16.1",
+    "@types/ssh2": "^0.5.50",
     "dotenv": "^10.0.0",
     "logform": "^2.3.2",
+    "ssh2": "^1.5.0",
     "winston": "^3.4.0"
   }
 }

--- a/src/classes/SshConnectionHandler.ts
+++ b/src/classes/SshConnectionHandler.ts
@@ -1,0 +1,23 @@
+export class SshConnectionHandler {
+
+  public onAuthentication = (): void => {};
+
+  public onClose = (): void => {};
+
+  public onEnd = (): void => {};
+
+  public onError = (): void => {};
+
+  public onHandshake = (): void => {};
+
+  public onReady = (): void => {};
+
+  public onRekey = (): void => {};
+
+  public onRequest = (): void => {};
+
+  public onSession = (): void => {};
+
+  public onTcpip = (): void => {};
+
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
 import * as Sentry from '@sentry/node';
+import { server } from './server';
+import { logger } from './logger';
+import type { ListenOptions } from 'net';
 
 if ('SENTRY_DSN' in process.env
  && 'SENTRY_ENVIRONMENT' in process.env) {
@@ -8,3 +11,15 @@ if ('SENTRY_DSN' in process.env
     environment: process.env.SENTRY_ENVIRONMENT,
   });
 }
+
+const listenOptions: ListenOptions = {
+  port: Number.parseInt(process.env.SSH_PORT ?? '22'),
+  host: process.env.SSH_HOST ?? '127.0.0.1',
+};
+
+server.listen(
+  listenOptions,
+  function () {
+    logger.info(`Listening for SSH requests on ${listenOptions.host ?? ''}:${listenOptions.port ?? ''}`);
+  },
+);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,31 @@
+import { Server } from 'ssh2';
+import type {
+  Connection,
+  ServerConfig,
+} from 'ssh2';
+import { SshConnectionHandler } from './classes/SshConnectionHandler';
+
+const serverConfig: ServerConfig = {
+  hostKeys: [],
+};
+
+const connectionListener = ( client: Connection ): void => {
+  const connectionHandler = new SshConnectionHandler();
+  client.on('authentication', connectionHandler.onAuthentication);
+  client.on('close', connectionHandler.onClose);
+  client.on('end', connectionHandler.onEnd);
+  client.on('error', connectionHandler.onError);
+  client.on('handshake', connectionHandler.onHandshake);
+  client.on('ready', connectionHandler.onReady);
+  client.on('rekey', connectionHandler.onRekey);
+  client.on('request', connectionHandler.onRequest);
+  client.on('session', connectionHandler.onSession);
+  client.on('tcpip', connectionHandler.onTcpip);
+};
+
+const server = new Server(
+  serverConfig,
+  connectionListener,
+);
+
+export { server };


### PR DESCRIPTION
This PR sets up the skeleton of the SSH2 server aspect of our SFTP server.

These event handlers don't actually perform any logic, but they create spaces to cover all of the connection events defined in the [ssh2 package documentation](https://www.npmjs.com/package/ssh2#connection-events)

You can test if this is working by updating your `.env` with the new values, and then running:

```
ssh 127.0.0.1 -p22222
```

You should then see:

```
Unable to negotiate with 127.0.0.1 port 22222: no matching host key type found. Their offer:
```

^ Note that I am using `SSH_PORT=222222` and if you use a different value you'd need to adjust the test accordingly.

Issue #3 