### PR TITLE
Support host keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,7 @@ SSH_PORT=${SSH_PORT}
 # The hostname the SSH service will listen on
 # See https://nodejs.org/api/net.html#serverlistenoptions-callback
 SSH_HOST=${SSH_HOSTNAME}
+
+# A filepath to the host key to use for this server
+# e.g. ./keys/host.key
+SSH_HOST_KEY_PATH=${SSH_HOST_KEY_PATH}

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,7 @@ dist
 
 # Ignore transpiled code
 /build
+
+# Ignore any host keys that were generated for the SSH service
+*.key
+*.key.pub

--- a/README.md
+++ b/README.md
@@ -10,14 +10,20 @@ This project uses NodeJS 16.x and contains an implementation of the SFTP protoco
 npm install
 ```
 
-2. Configure your `.env`
+2. Generate a host key for your SSH server
+
+```
+ssh-keygen -f ./keys/host.key -t ed25519 -N ""
+```
+
+3. Configure your `.env`
 
 ```
 cp .env.example .env
 vi .env
 ```
 
-3. Start the service
+4. Start the service
 
 ```
 npm start

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs';
 import { Server } from 'ssh2';
 import type {
   Connection,
@@ -5,8 +6,13 @@ import type {
 } from 'ssh2';
 import { SshConnectionHandler } from './classes/SshConnectionHandler';
 
+const hostKeys = [];
+if (typeof process.env.SSH_HOST_KEY_PATH == 'string') {
+  hostKeys.push(readFileSync(process.env.SSH_HOST_KEY_PATH));
+}
+
 const serverConfig: ServerConfig = {
-  hostKeys: [],
+  hostKeys,
 };
 
 const connectionListener = ( client: Connection ): void => {


### PR DESCRIPTION
This PR adds documentation for creating / configuring the server with a host key, and adds logic for using that host key when starting the SSH2 server.

To test this you should:

1. Follow the new README instructions for generating a host key.
2. Populate the `.env` with a path to your new host key
3. Start the server.

Once you do that you should be able to run `ssh 127.0.0.1 -p22222` and see no warnings / etc.  It will sit there doing nothing:

<img width="776" alt="image" src="https://user-images.githubusercontent.com/208884/149839092-00532447-f41d-40fa-9f24-08df85637ddc.png">

When you stop the server you should see a "Connection closed" message on your SSH client (though this is probably client specific)