### PR TITLE
Support "authentication"

### DIFF
--- a/src/classes/SshConnectionHandler.ts
+++ b/src/classes/SshConnectionHandler.ts
@@ -7,7 +7,7 @@ export class SshConnectionHandler {
    * https://datatracker.ietf.org/doc/html/rfc4252#section-5
    */
   public onAuthentication = (authContext: AuthContext): void => {
-    logger.debug('Authentication request recieved.', {
+    logger.debug('SSH authentication request recieved.', {
       username: authContext.username,
       method: authContext.method,
     });
@@ -24,22 +24,75 @@ export class SshConnectionHandler {
     }
   };
 
-  public onClose = (): void => {};
+  /**
+   * See: Connection Events (close)
+   * https://github.com/mscdex/ssh2#connection-events
+   */
+  public onClose = (): void => {
+    logger.debug('SSH connection has closed');
+  };
 
-  public onEnd = (): void => {};
+  /**
+   * See: Connection Events (end)
+   * https://github.com/mscdex/ssh2#connection-events
+   */
+  public onEnd = (): void => {
+    logger.debug('SSH connection is ending');
+  };
 
-  public onError = (): void => {};
+  /**
+   * See: Connection Events (error)
+   * https://github.com/mscdex/ssh2#connection-events
+   */
+  public onError = (error: Error): void => {
+    logger.info('SSH error: ', error);
+  };
 
-  public onHandshake = (): void => {};
+  /**
+   * See: Connection Events (handshake)
+   * https://github.com/mscdex/ssh2#connection-events
+   */
+  public onHandshake = (): void => {
+    logger.debug('SSH handshake complete');
+  };
 
-  public onReady = (): void => {};
+  /**
+   * See: Connection Events (ready)
+   * https://github.com/mscdex/ssh2#connection-events
+   */
+  public onReady = (): void => {
+    logger.debug('SSH connection is ready');
+  };
 
-  public onRekey = (): void => {};
+  /**
+   * See: Connection Events (rekey)
+   * https://github.com/mscdex/ssh2#connection-events
+   */
+  public onRekey = (): void => {
+    logger.debug('SSH connection has been re-keyed');
+  };
 
-  public onRequest = (): void => {};
+  /**
+   * See: Connection Events (request)
+   * https://github.com/mscdex/ssh2#connection-events
+   */
+  public onRequest = (): void => {
+    logger.debug('SSH request for a resource');
+  };
 
-  public onSession = (): void => {};
+  /**
+   * See: Connection Events (session)
+   * https://github.com/mscdex/ssh2#connection-events
+   */
+  public onSession = (): void => {
+    logger.debug('SSH request for a new session');
+  };
 
-  public onTcpip = (): void => {};
-
+  /**
+   * See: Connection Events (tcpip)
+   * https://github.com/mscdex/ssh2#connection-events
+   */
+  public onTcpip = (): void => {
+    logger.debug('SSH request for an outbound TCP connection');
+  };
 }

--- a/src/classes/SshConnectionHandler.ts
+++ b/src/classes/SshConnectionHandler.ts
@@ -1,6 +1,28 @@
-export class SshConnectionHandler {
+import { logger } from '../logger';
+import type { AuthContext } from 'ssh2';
 
-  public onAuthentication = (): void => {};
+export class SshConnectionHandler {
+  /**
+   * See: Authentication Requests
+   * https://datatracker.ietf.org/doc/html/rfc4252#section-5
+   */
+  public onAuthentication = (authContext: AuthContext): void => {
+    logger.debug('Authentication request recieved.', {
+      username: authContext.username,
+      method: authContext.method,
+    });
+    switch (authContext.method) {
+      case 'password':
+        authContext.accept();
+        return;
+      case 'none':
+      default:
+        authContext.reject(
+          ['password'],
+        );
+        return;
+    }
+  };
 
   public onClose = (): void => {};
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import type {
   Connection,
   ServerConfig,
 } from 'ssh2';
+import { logger } from './logger';
 import { SshConnectionHandler } from './classes/SshConnectionHandler';
 
 const hostKeys = [];
@@ -16,6 +17,7 @@ const serverConfig: ServerConfig = {
 };
 
 const connectionListener = ( client: Connection ): void => {
+  logger.debug('New connection');
   const connectionHandler = new SshConnectionHandler();
   client.on('authentication', connectionHandler.onAuthentication);
   client.on('close', connectionHandler.onClose);


### PR DESCRIPTION
This PR adds a handler for the `authentication` event, though the handler isn't very smart yet.  It tells the client to use a password and then accepts whatever password the client provides.

While I'd like to say this is a philosophical decision and social commentary on the dehumanizing impact of nations and borders, the reality is I want to confirm that the permanent SDK is ready for action before incorporating it into the authentication flow.

You'll know this is working if you get a password prompt after running

```
ssh 127.0.0.1 -p22222
```

You should also see the following output on the service console:

<img width="981" alt="image" src="https://user-images.githubusercontent.com/208884/150202419-9134a746-93fa-4f19-bb12-ac33c3111115.png">
