### PR TITLE
Use fileSystemCompatibleName for items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@fusionauth/typescript-client": "^1.38.0",
-        "@permanentorg/sdk": "^0.3.0",
+        "@permanentorg/sdk": "^0.4.0",
         "@sentry/node": "^6.16.1",
         "dotenv": "^10.0.0",
         "logform": "^2.3.2",
@@ -2653,9 +2653,9 @@
       }
     },
     "node_modules/@permanentorg/sdk": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.3.0.tgz",
-      "integrity": "sha512-/rU/k3/biULzeq3oHYlFNTIoqrXXryiEezx5vDCUP00TxKOvZ85ZyU18axUgjHQwdgx1Npx5LqgIfZN1fbP6vQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.4.0.tgz",
+      "integrity": "sha512-h367htlkMXruxsQopnKZIZF2H+w0TuGjYSJvHJzZCAqGABt4RmQ4BHNKbTZSsyeKcLThBlkt5WGgSbAMb9WatQ==",
       "dependencies": {
         "ajv": "^8.11.0",
         "node-fetch": "^2.6.7"
@@ -11753,9 +11753,9 @@
       }
     },
     "@permanentorg/sdk": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.3.0.tgz",
-      "integrity": "sha512-/rU/k3/biULzeq3oHYlFNTIoqrXXryiEezx5vDCUP00TxKOvZ85ZyU18axUgjHQwdgx1Npx5LqgIfZN1fbP6vQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.4.0.tgz",
+      "integrity": "sha512-h367htlkMXruxsQopnKZIZF2H+w0TuGjYSJvHJzZCAqGABt4RmQ4BHNKbTZSsyeKcLThBlkt5WGgSbAMb9WatQ==",
       "requires": {
         "ajv": "^8.11.0",
         "node-fetch": "^2.6.7"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fusionauth/typescript-client": "^1.38.0",
-    "@permanentorg/sdk": "^0.3.0",
+    "@permanentorg/sdk": "^0.4.0",
     "@sentry/node": "^6.16.1",
     "dotenv": "^10.0.0",
     "logform": "^2.3.2",

--- a/src/classes/PermanentFileSystem.ts
+++ b/src/classes/PermanentFileSystem.ts
@@ -93,13 +93,13 @@ export class PermanentFileSystem {
     const childName = path.basename(itemPath);
     const parentFolder = await this.loadFolder(parentPath);
     const targetIsRecord = parentFolder.records.some(
-      (record) => record.fileName === childName,
+      (record) => record.fileSystemCompatibleName === childName,
     );
     if (targetIsRecord) {
       return fs.constants.S_IFREG;
     }
     const targetIsFolder = parentFolder.folders.some(
-      (folder) => folder.name === childName,
+      (folder) => folder.fileSystemCompatibleName === childName,
     );
     if (targetIsFolder) {
       return fs.constants.S_IFDIR;
@@ -141,7 +141,7 @@ export class PermanentFileSystem {
     const parentFolder = await this.loadFolder(parentPath);
     const archiveId = getArchiveIdFromPath(parentPath);
     const targetRecord = parentFolder.records.find(
-      (record) => record.fileName === childName,
+      (record) => record.fileSystemCompatibleName === childName,
     );
     if (!targetRecord) {
       throw new Error('This file does not exist');
@@ -201,7 +201,7 @@ export class PermanentFileSystem {
       ? await this.loadArchiveFolders(archiveId)
       : (await this.loadFolder(parentPath)).folders;
     const targetFolder = childFolders.find(
-      (folder) => folder.name === childName,
+      (folder) => folder.fileSystemCompatibleName === childName,
     );
     if (!targetFolder) {
       throw new Error();
@@ -227,7 +227,7 @@ export class PermanentFileSystem {
     const archiveId = getArchiveIdFromPath(archivePath);
     const folders = await this.loadArchiveFolders(archiveId);
     return folders.map((archiveFolder) => generateFileEntry(
-      `${archiveFolder.name}`,
+      `${archiveFolder.fileSystemCompatibleName}`,
       generateDefaultAttributes(fs.constants.S_IFDIR),
     ));
   }

--- a/src/utils/generateFileEntriesForFolders.ts
+++ b/src/utils/generateFileEntriesForFolders.ts
@@ -8,7 +8,7 @@ export const generateFileEntriesForFolders = (
   folders: Folder[],
 ): FileEntry[] => folders.map(
   (folder) => generateFileEntry(
-    `${folder.name}`,
+    `${folder.fileSystemCompatibleName}`,
     generateDefaultAttributes(fs.constants.S_IFDIR),
   ),
 );

--- a/src/utils/generateFileEntriesForRecords.ts
+++ b/src/utils/generateFileEntriesForRecords.ts
@@ -8,13 +8,12 @@ export const generateFileEntriesForRecords = (
   records: Record[],
 ): FileEntry[] => records.reduce<FileEntry[]>(
   (fileEntries, record) => {
-    const { fileName } = record;
     try {
       const file = getOriginalFileForRecord(record);
       return [
         ...fileEntries,
         generateFileEntry(
-          fileName,
+          record.fileSystemCompatibleName,
           generateAttributesForFile(file),
         ),
       ];


### PR DESCRIPTION
This PR updates the SFTP service to use the latest Permanent SDK, and in particular stops using the Folder "name" property (which does not guarantee filesystem safety), instead using `fileSystemCompatibleName`.

It also updates `fileName` on Records to the new attribute name.

Resolves #60