### PR TITLE
Ensure unique file entries

### DIFF
--- a/src/classes/PermanentFileSystem.ts
+++ b/src/classes/PermanentFileSystem.ts
@@ -7,6 +7,7 @@ import {
   getRecord,
 } from '@permanentorg/sdk';
 import {
+  deduplicateFileEntries,
   generateAttributesForFile,
   generateAttributesForFolder,
   generateDefaultAttributes,
@@ -293,9 +294,9 @@ export class PermanentFileSystem {
         requestedPath,
       ),
     );
-    return [
+    return deduplicateFileEntries([
       ...folderFileEntities,
       ...recordFileEntities,
-    ];
+    ]);
   }
 }

--- a/src/utils/deduplicateFileEntries.ts
+++ b/src/utils/deduplicateFileEntries.ts
@@ -1,0 +1,21 @@
+import type { FileEntry } from 'ssh2';
+
+const findFirstIndexOfFilename = (
+  fileEntries: FileEntry[],
+  filename: string,
+): number => fileEntries.findIndex(
+  (fileEntry) => fileEntry.filename === filename,
+);
+
+const isFirstInstanceOfItsFilename = (
+  fileEntry: FileEntry,
+  index: number,
+  fileEntries: FileEntry[],
+): boolean => index === findFirstIndexOfFilename(
+  fileEntries,
+  fileEntry.filename,
+);
+
+export const deduplicateFileEntries = (
+  fileEntries: FileEntry[],
+): FileEntry[] => fileEntries.filter(isFirstInstanceOfItsFilename);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './deduplicateFileEntries';
 export * from './generateAttributesForFile';
 export * from './generateAttributesForFolder';
 export * from './generateDefaultAttributes';


### PR DESCRIPTION
This PR de-duplicates file entries generated from the Permanent API response when loading a folder.

Resolves #56