### PR TITLE
Share filesystems per user

### DIFF
--- a/src/classes/AuthenticationSession.ts
+++ b/src/classes/AuthenticationSession.ts
@@ -15,7 +15,7 @@ enum FusionAuthStatusCode {
 export class AuthenticationSession {
   public authToken = '';
 
-  private readonly authContext;
+  public readonly authContext;
 
   private readonly fusionAuthClient;
 

--- a/src/classes/SshSessionHandler.ts
+++ b/src/classes/SshSessionHandler.ts
@@ -1,21 +1,27 @@
 import { logger } from '../logger';
 import { SftpSessionHandler } from './SftpSessionHandler';
+import type { AuthenticationSession } from './AuthenticationSession';
+import type { PermanentFileSystemManager } from './PermanentFileSystemManager';
 import type {
   Session,
   SFTPWrapper,
 } from 'ssh2';
 
 export class SshSessionHandler {
-  private readonly authToken: string;
+  private readonly permanentFileSystemManager: PermanentFileSystemManager;
+
+  private readonly authenticationSession: AuthenticationSession;
 
   private readonly session: Session;
 
   public constructor(
     session: Session,
-    authToken: string,
+    authenticationSession: AuthenticationSession,
+    permanentFileSystemManager: PermanentFileSystemManager,
   ) {
     this.session = session;
-    this.authToken = authToken;
+    this.authenticationSession = authenticationSession;
+    this.permanentFileSystemManager = permanentFileSystemManager;
   }
 
   /**
@@ -29,7 +35,8 @@ export class SshSessionHandler {
     const sftpConnection = accept();
     const sftpSessionHandler = new SftpSessionHandler(
       sftpConnection,
-      this.authToken,
+      this.authenticationSession,
+      this.permanentFileSystemManager,
     );
     sftpConnection.on('OPEN', sftpSessionHandler.openHandler);
     sftpConnection.on('READ', sftpSessionHandler.readHandler);

--- a/src/classes/index.ts
+++ b/src/classes/index.ts
@@ -1,0 +1,6 @@
+export * from './AuthenticationSession';
+export * from './PermanentFileSystem';
+export * from './PermanentFileSystemManager';
+export * from './SftpSessionHandler';
+export * from './SshConnectionHandler';
+export * from './SshSessionHandler';

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,10 @@
 import { readFileSync } from 'fs';
 import { Server } from 'ssh2';
 import { logger } from './logger';
-import { SshConnectionHandler } from './classes/SshConnectionHandler';
+import {
+  SshConnectionHandler,
+  PermanentFileSystemManager,
+} from './classes';
 import type {
   Connection,
   ServerConfig,
@@ -17,9 +20,11 @@ const serverConfig: ServerConfig = {
   debug: (message) => logger.silly(message),
 };
 
+const permanentFileSystemManager = new PermanentFileSystemManager();
+
 const connectionListener = (client: Connection): void => {
   logger.verbose('New connection');
-  const connectionHandler = new SshConnectionHandler();
+  const connectionHandler = new SshConnectionHandler(permanentFileSystemManager);
   client.on('authentication', connectionHandler.onAuthentication);
   client.on('close', connectionHandler.onClose);
   client.on('end', connectionHandler.onEnd);


### PR DESCRIPTION
This PR creates a "manager" layer that will provide the same filesystem for any connection that has been established on behalf of a given user.  It will also ensure that those filesystems are deleted after 5 minutes of inactivity.

Resolves #76 