### PR TITLE
Remove arrow functions for class methods

### DIFF
--- a/src/classes/SftpSessionHandler.ts
+++ b/src/classes/SftpSessionHandler.ts
@@ -56,12 +56,12 @@ export class SftpSessionHandler {
    * Also: Opening, Creating, and Closing Files
    * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.3
    */
-  public openHandler = (
+  public openHandler(
     reqId: number,
     filePath: string,
     flags: number,
     attrs: Attributes,
-  ): void => {
+  ): void {
     logger.verbose(
       'Request: SFTP file open (SSH_FXP_OPEN)',
       {
@@ -100,7 +100,7 @@ export class SftpSessionHandler {
           flags,
         );
       });
-  };
+  }
 
   /**
    * See: SFTP events (READ)
@@ -108,12 +108,12 @@ export class SftpSessionHandler {
    * Also: Reading and Writing
    * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.4
    */
-  public readHandler = (
+  public readHandler(
     reqId: number,
     handle: Buffer,
     offset: number,
     length: number,
-  ): void => {
+  ): void {
     logger.verbose(
       'Request: SFTP read file (SSH_FXP_READ)',
       {
@@ -180,7 +180,7 @@ export class SftpSessionHandler {
         );
         this.sftpConnection.status(reqId, SFTP_STATUS_CODE.FAILURE);
       });
-  };
+  }
 
   /**
    * See: SFTP events (WRITE)
@@ -188,12 +188,12 @@ export class SftpSessionHandler {
    * Also: Reading and Writing
    * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.4
    */
-  public writeHandler = (
+  public writeHandler(
     reqId: number,
     handle: Buffer,
     offset: number,
     data: Buffer,
-  ): void => {
+  ): void {
     logger.verbose(
       'Request: SFTP write file (SSH_FXP_WRITE)',
       { reqId, handle, offset },
@@ -243,7 +243,7 @@ export class SftpSessionHandler {
         this.sftpConnection.status(reqId, SFTP_STATUS_CODE.OK);
       },
     );
-  };
+  }
 
   /**
    * See: SFTP events (FSTAT)
@@ -251,10 +251,10 @@ export class SftpSessionHandler {
    * Also: Retrieving File Attributes
    * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.8
    */
-  public fstatHandler = (
+  public fstatHandler(
     reqId: number,
     itemPath: Buffer,
-  ): void => {
+  ): void {
     logger.verbose(
       'Request: SFTP read open file statistics (SSH_FXP_FSTAT)',
       { reqId, itemPath },
@@ -273,7 +273,7 @@ export class SftpSessionHandler {
       return;
     }
     this.genericStatHandler(reqId, itemPath);
-  };
+  }
 
   /**
    * See: SFTP events (FSETSTAT)
@@ -282,9 +282,9 @@ export class SftpSessionHandler {
    * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.9
    */
   // eslint-disable-next-line class-methods-use-this
-  public fsetStatHandler = (): void => {
+  public fsetStatHandler(): void {
     logger.error('UNIMPLEMENTED Request: SFTP write open file statistics (SSH_FXP_FSETSTAT)');
-  };
+  }
 
   /**
    * See: SFTP events (CLOSE)
@@ -292,7 +292,7 @@ export class SftpSessionHandler {
    * Also: Opening, Creating, and Closing Files
    * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.3
    */
-  public closeHandler = (reqId: number, handle: Buffer): void => {
+  public closeHandler(reqId: number, handle: Buffer): void {
     logger.verbose(
       'Request: SFTP close file (SSH_FXP_CLOSE)',
       { reqId, handle },
@@ -338,7 +338,7 @@ export class SftpSessionHandler {
       },
     );
     this.sftpConnection.status(reqId, SFTP_STATUS_CODE.OK);
-  };
+  }
 
   /**
    * See: SFTP events (OPENDIR)
@@ -346,7 +346,7 @@ export class SftpSessionHandler {
    * Also: Scanning Directories
    * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.7
    */
-  public openDirHandler = (reqId: number, dirPath: string): void => {
+  public openDirHandler(reqId: number, dirPath: string): void {
     logger.verbose(
       'SFTP open directory request (SSH_FXP_OPENDIR)',
       { reqId, dirPath },
@@ -375,7 +375,7 @@ export class SftpSessionHandler {
         );
         this.sftpConnection.status(reqId, SFTP_STATUS_CODE.FAILURE);
       });
-  };
+  }
 
   /**
    * See: SFTP events (READDIR)
@@ -383,7 +383,7 @@ export class SftpSessionHandler {
    * Also: Scanning Directories
    * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.7
    */
-  public readDirHandler = (reqId: number, handle: Buffer): void => {
+  public readDirHandler(reqId: number, handle: Buffer): void {
     logger.verbose(
       'Request: SFTP read directory (SSH_FXP_READDIR)',
       { reqId, handle },
@@ -404,7 +404,7 @@ export class SftpSessionHandler {
       this.openDirectories.delete(handle.toString());
       this.sftpConnection.status(reqId, SFTP_STATUS_CODE.EOF);
     }
-  };
+  }
 
   /**
    * See: SFTP events (LSTAT)
@@ -412,16 +412,16 @@ export class SftpSessionHandler {
    * Also: Retrieving File Attributes
    * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.8
    */
-  public lstatHandler = (
+  public lstatHandler(
     reqId: number,
     itemPath: Buffer,
-  ): void => {
+  ): void {
     logger.verbose(
       'Request: SFTP read file statistics without following symbolic links (SSH_FXP_LSTAT)',
       { reqId, itemPath },
     );
     this.genericStatHandler(reqId, itemPath);
-  };
+  }
 
   /**
    * See: SFTP events (STAT)
@@ -429,16 +429,16 @@ export class SftpSessionHandler {
    * Also: Retrieving File Attributes
    * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.8
    */
-  public statHandler = (
+  public statHandler(
     reqId: number,
     itemPath: Buffer,
-  ): void => {
+  ): void {
     logger.verbose(
       'Request: SFTP read file statistics following symbolic links (SSH_FXP_STAT)',
       { reqId, itemPath },
     );
     this.genericStatHandler(reqId, itemPath);
-  };
+  }
 
   /**
    * See: SFTP events (REMOVE)
@@ -447,9 +447,9 @@ export class SftpSessionHandler {
    * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.5
    */
   // eslint-disable-next-line class-methods-use-this
-  public removeHandler = (): void => {
+  public removeHandler(): void {
     logger.error('UNIMPLEMENTED Request: SFTP remove file (SSH_FXP_REMOVE)');
-  };
+  }
 
   /**
    * See: SFTP events (RMDIR)
@@ -458,9 +458,9 @@ export class SftpSessionHandler {
    * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.6
    */
   // eslint-disable-next-line class-methods-use-this
-  public rmDirHandler = (): void => {
+  public rmDirHandler(): void {
     logger.error('UNIMPLEMENTED Request: SFTP remove directory (SSH_FXP_RMDIR)');
-  };
+  }
 
   /**
    * See: SFTP events (REALPATH)
@@ -468,7 +468,7 @@ export class SftpSessionHandler {
    * Also: Canonicalizing the Server-Side Path Name
    * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.11
    */
-  public realPathHandler = (reqId: number, relativePath: string): void => {
+  public realPathHandler(reqId: number, relativePath: string): void {
     logger.verbose(
       'Request: SFTP canonicalize path (SSH_FXP_REALPATH)',
       { reqId, relativePath },
@@ -497,7 +497,7 @@ export class SftpSessionHandler {
         );
         this.sftpConnection.status(reqId, SFTP_STATUS_CODE.NO_SUCH_FILE);
       });
-  };
+  }
 
   /**
    * See: SFTP events (READLINK)
@@ -506,9 +506,9 @@ export class SftpSessionHandler {
    * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.10
    */
   // eslint-disable-next-line class-methods-use-this
-  public readLinkHandler = (): void => {
+  public readLinkHandler(): void {
     logger.error('UNIMPLEMENTED Request: SFTP read link (SSH_FXP_READLINK)');
-  };
+  }
 
   /**
    * See: SFTP events (SETSTAT)
@@ -516,11 +516,11 @@ export class SftpSessionHandler {
    * Also: Setting File Attributes
    * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.9
    */
-  public setStatHandler = (
+  public setStatHandler(
     reqId: number,
     filePath: string,
     attrs: Attributes,
-  ): void => {
+  ): void {
     logger.verbose(
       'Request: SFTP set file attributes request (SSH_FXP_SETSTAT)',
       { reqId, filePath, attrs },
@@ -533,7 +533,7 @@ export class SftpSessionHandler {
       },
     );
     this.sftpConnection.status(reqId, SFTP_STATUS_CODE.OK);
-  };
+  }
 
   /**
    * See: SFTP events (MKDIR)
@@ -541,11 +541,11 @@ export class SftpSessionHandler {
    * Also: Creating and Deleting Directories
    * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.6
    */
-  public mkDirHandler = (
+  public mkDirHandler(
     reqId: number,
     dirPath: string,
     attrs: Attributes,
-  ): void => {
+  ): void {
     logger.verbose(
       'Request: SFTP create directory (SSH_FXP_MKDIR)',
       { reqId, dirPath, attrs },
@@ -568,7 +568,7 @@ export class SftpSessionHandler {
         );
         this.sftpConnection.status(reqId, SFTP_STATUS_CODE.FAILURE);
       });
-  };
+  }
 
   /**
    * See: SFTP events (RENAME)
@@ -577,9 +577,9 @@ export class SftpSessionHandler {
    * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.5
    */
   // eslint-disable-next-line class-methods-use-this
-  public renameHandler = (): void => {
+  public renameHandler(): void {
     logger.error('UNIMPLEMENTED Request: SFTP file rename (SSH_FXP_RENAME)');
-  };
+  }
 
   /**
    * See: SFTP events (SYMLINK)
@@ -588,11 +588,11 @@ export class SftpSessionHandler {
    * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.10
    */
   // eslint-disable-next-line class-methods-use-this
-  public symLinkHandler = (): void => {
+  public symLinkHandler(): void {
     logger.error('UNIMPLEMENTED Request: SFTP create symlink (SSH_FXP_SYMLINK)');
-  };
+  }
 
-  private readonly genericStatHandler = (reqId: number, itemPath: Buffer): void => {
+  private genericStatHandler(reqId: number, itemPath: Buffer): void {
     this.getCurrentPermanentFileSystem().getItemAttributes(itemPath.toString())
       .then((attrs) => {
         logger.verbose(
@@ -614,13 +614,13 @@ export class SftpSessionHandler {
         );
         this.sftpConnection.status(reqId, SFTP_STATUS_CODE.NO_SUCH_FILE);
       });
-  };
+  }
 
-  private readonly openExistingFileHandler = (
+  private openExistingFileHandler(
     reqId: number,
     filePath: string,
     flags: number,
-  ): void => {
+  ): void {
     const handle = generateHandle();
     const flagsString = ssh2.utils.sftp.flagsToString(flags);
     this.getCurrentPermanentFileSystem().loadFile(filePath)
@@ -684,13 +684,13 @@ export class SftpSessionHandler {
         );
         this.sftpConnection.status(reqId, SFTP_STATUS_CODE.FAILURE);
       });
-  };
+  }
 
-  private readonly openNewFileHandler = (
+  private openNewFileHandler(
     reqId: number,
     filePath: string,
     flags: number,
-  ): void => {
+  ): void {
     const handle = generateHandle();
     const flagsString = ssh2.utils.sftp.flagsToString(flags);
     const parentPath = path.dirname(filePath);
@@ -750,7 +750,7 @@ export class SftpSessionHandler {
         );
         this.sftpConnection.status(reqId, SFTP_STATUS_CODE.NO_SUCH_PATH);
       });
-  };
+  }
 
   private getCurrentPermanentFileSystem(): PermanentFileSystem {
     return this.permanentFileSystemManager

--- a/src/classes/SshConnectionHandler.ts
+++ b/src/classes/SshConnectionHandler.ts
@@ -20,7 +20,7 @@ export class SshConnectionHandler {
    * See: Authentication Requests
    * https://datatracker.ietf.org/doc/html/rfc4252#section-5
    */
-  public onAuthentication = (authContext: AuthContext): void => {
+  public onAuthentication(authContext: AuthContext): void {
     logger.verbose('SSH authentication request recieved.', {
       username: authContext.username,
       method: authContext.method,
@@ -38,78 +38,78 @@ export class SshConnectionHandler {
           ['keyboard-interactive'],
         );
     }
-  };
+  }
 
   /**
    * See: Connection Events (close)
    * https://github.com/mscdex/ssh2#connection-events
    */
   // eslint-disable-next-line class-methods-use-this
-  public onClose = (): void => {
+  public onClose(): void {
     logger.verbose('SSH connection has closed');
-  };
+  }
 
   /**
    * See: Connection Events (end)
    * https://github.com/mscdex/ssh2#connection-events
    */
   // eslint-disable-next-line class-methods-use-this
-  public onEnd = (): void => {
+  public onEnd(): void {
     logger.verbose('SSH connection is ending');
-  };
+  }
 
   /**
    * See: Connection Events (error)
    * https://github.com/mscdex/ssh2#connection-events
    */
   // eslint-disable-next-line class-methods-use-this
-  public onError = (error: Error): void => {
+  public onError(error: Error): void {
     logger.verbose('SSH error: ', error);
-  };
+  }
 
   /**
    * See: Connection Events (handshake)
    * https://github.com/mscdex/ssh2#connection-events
    */
   // eslint-disable-next-line class-methods-use-this
-  public onHandshake = (): void => {
+  public onHandshake(): void {
     logger.verbose('SSH handshake complete');
-  };
+  }
 
   /**
    * See: Connection Events (ready)
    * https://github.com/mscdex/ssh2#connection-events
    */
   // eslint-disable-next-line class-methods-use-this
-  public onReady = (): void => {
+  public onReady(): void {
     logger.verbose('SSH connection is ready');
-  };
+  }
 
   /**
    * See: Connection Events (rekey)
    * https://github.com/mscdex/ssh2#connection-events
    */
   // eslint-disable-next-line class-methods-use-this
-  public onRekey = (): void => {
+  public onRekey(): void {
     logger.verbose('SSH connection has been re-keyed');
-  };
+  }
 
   /**
    * See: Connection Events (request)
    * https://github.com/mscdex/ssh2#connection-events
    */
   // eslint-disable-next-line class-methods-use-this
-  public onRequest = (): void => {
+  public onRequest(): void {
     logger.verbose('SSH request for a resource');
-  };
+  }
 
   /**
    * See: Connection Events (session)
    * https://github.com/mscdex/ssh2#connection-events
    */
-  public onSession = (
+  public onSession(
     accept: () => Session,
-  ): void => {
+  ): void {
     logger.verbose('SSH request for a new session');
     const session = accept();
     if (this.authSession === undefined) {
@@ -122,17 +122,17 @@ export class SshConnectionHandler {
       this.authSession,
       this.permanentFileSystemManager,
     );
-    session.on('sftp', sessionHandler.onSftp);
-    session.on('close', sessionHandler.onClose);
-    session.on('eof', sessionHandler.onEof);
-  };
+    session.on('sftp', sessionHandler.onSftp.bind(sessionHandler));
+    session.on('close', sessionHandler.onClose.bind(sessionHandler));
+    session.on('eof', sessionHandler.onEof.bind(sessionHandler));
+  }
 
   /**
    * See: Connection Events (tcpip)
    * https://github.com/mscdex/ssh2#connection-events
    */
   // eslint-disable-next-line class-methods-use-this
-  public onTcpip = (): void => {
+  public onTcpip(): void {
     logger.verbose('SSH request for an outbound TCP connection');
-  };
+  }
 }

--- a/src/classes/SshSessionHandler.ts
+++ b/src/classes/SshSessionHandler.ts
@@ -28,9 +28,9 @@ export class SshSessionHandler {
    * See: Session Events (sftp)
    * https://github.com/mscdex/ssh2#session-events
    */
-  public onSftp = (
+  public onSftp(
     accept: () => SFTPWrapper,
-  ): void => {
+  ): void {
     logger.verbose('SFTP requested');
     const sftpConnection = accept();
     const sftpSessionHandler = new SftpSessionHandler(
@@ -38,36 +38,36 @@ export class SshSessionHandler {
       this.authenticationSession,
       this.permanentFileSystemManager,
     );
-    sftpConnection.on('OPEN', sftpSessionHandler.openHandler);
-    sftpConnection.on('READ', sftpSessionHandler.readHandler);
-    sftpConnection.on('WRITE', sftpSessionHandler.writeHandler);
-    sftpConnection.on('FSTAT', sftpSessionHandler.fstatHandler);
-    sftpConnection.on('FSETSTAT', sftpSessionHandler.fsetStatHandler);
-    sftpConnection.on('CLOSE', sftpSessionHandler.closeHandler);
-    sftpConnection.on('OPENDIR', sftpSessionHandler.openDirHandler);
-    sftpConnection.on('READDIR', sftpSessionHandler.readDirHandler);
-    sftpConnection.on('LSTAT', sftpSessionHandler.lstatHandler);
-    sftpConnection.on('STAT', sftpSessionHandler.statHandler);
-    sftpConnection.on('REMOVE', sftpSessionHandler.removeHandler);
-    sftpConnection.on('RMDIR', sftpSessionHandler.rmDirHandler);
-    sftpConnection.on('REALPATH', sftpSessionHandler.realPathHandler);
-    sftpConnection.on('READLINK', sftpSessionHandler.readLinkHandler);
-    sftpConnection.on('SETSTAT', sftpSessionHandler.setStatHandler);
-    sftpConnection.on('MKDIR', sftpSessionHandler.mkDirHandler);
-    sftpConnection.on('RENAME', sftpSessionHandler.renameHandler);
-    sftpConnection.on('SYMLINK', sftpSessionHandler.symLinkHandler);
-  };
+    sftpConnection.on('OPEN', sftpSessionHandler.openHandler.bind(sftpSessionHandler));
+    sftpConnection.on('READ', sftpSessionHandler.readHandler.bind(sftpSessionHandler));
+    sftpConnection.on('WRITE', sftpSessionHandler.writeHandler.bind(sftpSessionHandler));
+    sftpConnection.on('FSTAT', sftpSessionHandler.fstatHandler.bind(sftpSessionHandler));
+    sftpConnection.on('FSETSTAT', sftpSessionHandler.fsetStatHandler.bind(sftpSessionHandler));
+    sftpConnection.on('CLOSE', sftpSessionHandler.closeHandler.bind(sftpSessionHandler));
+    sftpConnection.on('OPENDIR', sftpSessionHandler.openDirHandler.bind(sftpSessionHandler));
+    sftpConnection.on('READDIR', sftpSessionHandler.readDirHandler.bind(sftpSessionHandler));
+    sftpConnection.on('LSTAT', sftpSessionHandler.lstatHandler.bind(sftpSessionHandler));
+    sftpConnection.on('STAT', sftpSessionHandler.statHandler.bind(sftpSessionHandler));
+    sftpConnection.on('REMOVE', sftpSessionHandler.removeHandler.bind(sftpSessionHandler));
+    sftpConnection.on('RMDIR', sftpSessionHandler.rmDirHandler.bind(sftpSessionHandler));
+    sftpConnection.on('REALPATH', sftpSessionHandler.realPathHandler.bind(sftpSessionHandler));
+    sftpConnection.on('READLINK', sftpSessionHandler.readLinkHandler.bind(sftpSessionHandler));
+    sftpConnection.on('SETSTAT', sftpSessionHandler.setStatHandler.bind(sftpSessionHandler));
+    sftpConnection.on('MKDIR', sftpSessionHandler.mkDirHandler.bind(sftpSessionHandler));
+    sftpConnection.on('RENAME', sftpSessionHandler.renameHandler.bind(sftpSessionHandler));
+    sftpConnection.on('SYMLINK', sftpSessionHandler.symLinkHandler.bind(sftpSessionHandler));
+  }
 
   /**
    * See: Session Events (close)
    * https://github.com/mscdex/ssh2#session-events
    */
   // eslint-disable-next-line class-methods-use-this
-  public onClose = (): void => {
+  public onClose(): void {
     logger.verbose('SSH session closed');
-  };
+  }
 
-  public onEof = (): void => {
+  public onEof(): void {
     // This addresses a bug in the ssh2 library where EOF is not properly
     // handled for sftp connections.
     // An upstream PR that would fix the behavior: https://github.com/mscdex/ssh2/pull/1111
@@ -81,5 +81,5 @@ export class SshSessionHandler {
     // !!BEWARE: THERE BE DRAGONS HERE!!
     // @ts-expect-error because `_channel` is private / isn't actually documented.
     this.session._channel.end(); // eslint-disable-line max-len, no-underscore-dangle, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-  };
+  }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,16 +25,16 @@ const permanentFileSystemManager = new PermanentFileSystemManager();
 const connectionListener = (client: Connection): void => {
   logger.verbose('New connection');
   const connectionHandler = new SshConnectionHandler(permanentFileSystemManager);
-  client.on('authentication', connectionHandler.onAuthentication);
-  client.on('close', connectionHandler.onClose);
-  client.on('end', connectionHandler.onEnd);
-  client.on('error', connectionHandler.onError);
-  client.on('handshake', connectionHandler.onHandshake);
-  client.on('ready', connectionHandler.onReady);
-  client.on('rekey', connectionHandler.onRekey);
-  client.on('request', connectionHandler.onRequest);
-  client.on('session', connectionHandler.onSession);
-  client.on('tcpip', connectionHandler.onTcpip);
+  client.on('authentication', connectionHandler.onAuthentication.bind(connectionHandler));
+  client.on('close', connectionHandler.onClose.bind(connectionHandler));
+  client.on('end', connectionHandler.onEnd.bind(connectionHandler));
+  client.on('error', connectionHandler.onError.bind(connectionHandler));
+  client.on('handshake', connectionHandler.onHandshake.bind(connectionHandler));
+  client.on('ready', connectionHandler.onReady.bind(connectionHandler));
+  client.on('rekey', connectionHandler.onRekey.bind(connectionHandler));
+  client.on('request', connectionHandler.onRequest.bind(connectionHandler));
+  client.on('session', connectionHandler.onSession.bind(connectionHandler));
+  client.on('tcpip', connectionHandler.onTcpip.bind(connectionHandler));
 };
 
 const server = new Server(


### PR DESCRIPTION
This PR updates some of our class functions so they are more consistent in NOT using arrow functions.

The functionality should all be the same, though this does impact some inner workings of how the functions themselves are created and called.

Resolves #85