### PR TITLE
Update permanent sdk to v0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@fusionauth/typescript-client": "^1.38.0",
-        "@permanentorg/sdk": "^0.5.0",
+        "@permanentorg/sdk": "^0.5.1",
         "@sentry/node": "^6.16.1",
         "dotenv": "^10.0.0",
         "logform": "^2.3.2",
@@ -2655,9 +2655,9 @@
       }
     },
     "node_modules/@permanentorg/sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.5.0.tgz",
-      "integrity": "sha512-r7iG02K+NXUOYqtK/FooTRD8WgtVITSg5xPUblO+vDKdIi463GvkNNPb5Zbl/mU0t66qfIQNnuuxM0RjjdiT7A==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.5.1.tgz",
+      "integrity": "sha512-pz6ssEPrm8cJ6h8nV5mM/Nm4vav2cjlT4VoLRDp/kAJgEbEYgshANEqjcWWvEl98jjfCDIbMOOLKYIXHhCWvgw==",
       "dependencies": {
         "ajv": "^8.11.0",
         "form-data": "^2.3.3",
@@ -11770,9 +11770,9 @@
       }
     },
     "@permanentorg/sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.5.0.tgz",
-      "integrity": "sha512-r7iG02K+NXUOYqtK/FooTRD8WgtVITSg5xPUblO+vDKdIi463GvkNNPb5Zbl/mU0t66qfIQNnuuxM0RjjdiT7A==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.5.1.tgz",
+      "integrity": "sha512-pz6ssEPrm8cJ6h8nV5mM/Nm4vav2cjlT4VoLRDp/kAJgEbEYgshANEqjcWWvEl98jjfCDIbMOOLKYIXHhCWvgw==",
       "requires": {
         "ajv": "^8.11.0",
         "form-data": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fusionauth/typescript-client": "^1.38.0",
-    "@permanentorg/sdk": "^0.5.0",
+    "@permanentorg/sdk": "^0.5.1",
     "@sentry/node": "^6.16.1",
     "dotenv": "^10.0.0",
     "logform": "^2.3.2",


### PR DESCRIPTION
This PR updates the SDK to 0.5.1 which resolves an issue where certain archive root folders were resulting in SDK errors.

I don't think we had an open issue for this here, but it was causing failures in download in certain legacy cases.