### PR TITLE
Use slug instead of archive ID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@fusionauth/typescript-client": "^1.38.0",
-        "@permanentorg/sdk": "^0.5.1",
+        "@permanentorg/sdk": "^0.5.2",
         "@sentry/node": "^6.16.1",
         "dotenv": "^10.0.0",
         "logform": "^2.3.2",
@@ -2655,9 +2655,9 @@
       }
     },
     "node_modules/@permanentorg/sdk": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.5.1.tgz",
-      "integrity": "sha512-pz6ssEPrm8cJ6h8nV5mM/Nm4vav2cjlT4VoLRDp/kAJgEbEYgshANEqjcWWvEl98jjfCDIbMOOLKYIXHhCWvgw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.5.2.tgz",
+      "integrity": "sha512-i8iRHi4/mvsWu1NK1LJ5rQBQHXuTzb9yeNJ23hvWsv0i9YN/NYaehzdugFoZK+zLcbFv0QwjCfluJUxi9HFSUA==",
       "dependencies": {
         "ajv": "^8.11.0",
         "form-data": "^2.3.3",
@@ -11770,9 +11770,9 @@
       }
     },
     "@permanentorg/sdk": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.5.1.tgz",
-      "integrity": "sha512-pz6ssEPrm8cJ6h8nV5mM/Nm4vav2cjlT4VoLRDp/kAJgEbEYgshANEqjcWWvEl98jjfCDIbMOOLKYIXHhCWvgw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.5.2.tgz",
+      "integrity": "sha512-i8iRHi4/mvsWu1NK1LJ5rQBQHXuTzb9yeNJ23hvWsv0i9YN/NYaehzdugFoZK+zLcbFv0QwjCfluJUxi9HFSUA==",
       "requires": {
         "ajv": "^8.11.0",
         "form-data": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fusionauth/typescript-client": "^1.38.0",
-    "@permanentorg/sdk": "^0.5.1",
+    "@permanentorg/sdk": "^0.5.2",
     "@sentry/node": "^6.16.1",
     "dotenv": "^10.0.0",
     "logform": "^2.3.2",

--- a/src/utils/getArchiveIdFromPath.ts
+++ b/src/utils/getArchiveIdFromPath.ts
@@ -1,8 +1,0 @@
-export const getArchiveIdFromPath = (archivePath: string): number => {
-  const archiveIdPattern = /^\/archives\/[^/]* \((\d+)\)(\/.*)?$/;
-  const matches = archiveIdPattern.exec(archivePath);
-  if (matches === null) {
-    return -1;
-  }
-  return parseInt(matches[1], 10);
-};

--- a/src/utils/getArchiveSlugFromPath.ts
+++ b/src/utils/getArchiveSlugFromPath.ts
@@ -1,0 +1,8 @@
+export const getArchiveSlugFromPath = (archivePath: string): string => {
+  const archiveIdPattern = /^\/archives\/[^/]* \(([^/]+)\)(\/.*)?$/;
+  const matches = archiveIdPattern.exec(archivePath);
+  if (matches === null) {
+    throw new Error('The specified path did not contain an archive slug');
+  }
+  return matches[1];
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,6 +5,6 @@ export * from './generateDefaultAttributes';
 export * from './generateFileEntriesForArchiveRecords';
 export * from './generateFileEntriesForFolders';
 export * from './generateFileEntry';
-export * from './getArchiveIdFromPath';
+export * from './getArchiveSlugFromPath';
 export * from './getLongname';
 export * from './getOriginalFileForArchiveRecord';


### PR DESCRIPTION
This PR changes the value used in archive folder paths from the archive's ID to the archive's slug

Resolves #91