### PR TITLE
Fix mtime dates

### DIFF
--- a/src/utils/generateAttributesForArchive.ts
+++ b/src/utils/generateAttributesForArchive.ts
@@ -1,0 +1,13 @@
+import fs from 'fs';
+import { generateDefaultMode } from './generateDefaultMode';
+import type { Attributes } from 'ssh2';
+import type { Archive } from '@permanentorg/sdk';
+
+export const generateAttributesForArchive = (archive: Archive): Attributes => ({
+  mode: generateDefaultMode(fs.constants.S_IFDIR),
+  uid: 0,
+  gid: 0,
+  size: 0,
+  atime: 0,
+  mtime: archive.updatedAt.getTime() / 1000,
+});

--- a/src/utils/generateAttributesForFile.ts
+++ b/src/utils/generateAttributesForFile.ts
@@ -12,7 +12,7 @@ export const generateAttributesForFile = (file?: File): Attributes => (
       gid: 0,
       size: file.size,
       atime: 0,
-      mtime: file.updatedAt.getTime(),
+      mtime: file.updatedAt.getTime() / 1000,
     }
     : generateDefaultAttributes(fs.constants.S_IFREG)
 );

--- a/src/utils/generateAttributesForFolder.ts
+++ b/src/utils/generateAttributesForFolder.ts
@@ -9,5 +9,5 @@ export const generateAttributesForFolder = (folder: Folder): Attributes => ({
   gid: 0,
   size: folder.size,
   atime: 0,
-  mtime: folder.updatedAt.getTime(),
+  mtime: folder.updatedAt.getTime() / 1000,
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './deduplicateFileEntries';
+export * from './generateAttributesForArchive';
 export * from './generateAttributesForFile';
 export * from './generateAttributesForFolder';
 export * from './generateDefaultAttributes';


### PR DESCRIPTION
This PR fixes a few bugs related to the reported mtimes for files and folders.  In particular it now properly uses seconds (instead of ms) when reporting the dates.  It also uses the archive data for archive folders.

It does not address the `/archives` folder, which does not actually exist in permanent and should likely be linked to the user's account creation date, but I'd like to address that as part of #100 

Note this can be tested locally using the `rclone lsjson` command which will show the mtimes associated with various items in a path.

Resolves #98 