### PR TITLE
Add cache bypasses

### DIFF
--- a/src/classes/SftpSessionHandler.ts
+++ b/src/classes/SftpSessionHandler.ts
@@ -653,7 +653,7 @@ export class SftpSessionHandler {
   ): void {
     const handle = generateHandle();
     const flagsString = ssh2.utils.sftp.flagsToString(flags);
-    this.getCurrentPermanentFileSystem().loadFile(filePath)
+    this.getCurrentPermanentFileSystem().loadFile(filePath, true)
       .then((file) => {
         // These flags are explained in the NodeJS fs documentation:
         // https://nodejs.org/api/fs.html#file-system-flags


### PR DESCRIPTION
This PR adds some limits to when the cache is used in an attempt to avoid cases when new content isn't available in the cache.  It maintains the use of caching for:

1. directory navigation (e.g. loading a file won't cause one API call per directory depth if the paths had already been loaded before).
2. directory content listing (e.g. running `ls` won't cause one API call per record if the records already existed).

Related to #102