### PR TITLE
Prevent double closing

### DIFF
--- a/src/classes/SftpSessionHandler.ts
+++ b/src/classes/SftpSessionHandler.ts
@@ -329,7 +329,6 @@ export class SftpSessionHandler {
     );
     const temporaryFile = this.openTemporaryFiles.get(handle.toString());
     if (temporaryFile) {
-      fs.close(temporaryFile.fd);
       const { size } = fs.statSync(temporaryFile.name);
       this.getCurrentPermanentFileSystem().createFile(
         temporaryFile.path,


### PR DESCRIPTION
This PR removes a nasty bug that was coming from double-closing of the same file ID (the `tmp` library closes files as part of cleanup, so we don't need to close it directly).

Issue #111
Issue #99