### PR TITLE
Implement support for sftp RMDIR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@fusionauth/typescript-client": "^1.38.0",
-        "@permanentorg/sdk": "^0.5.2",
+        "@permanentorg/sdk": "^0.5.3",
         "@sentry/node": "^6.16.1",
         "dotenv": "^10.0.0",
         "logform": "^2.3.2",
@@ -2655,9 +2655,9 @@
       }
     },
     "node_modules/@permanentorg/sdk": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.5.2.tgz",
-      "integrity": "sha512-i8iRHi4/mvsWu1NK1LJ5rQBQHXuTzb9yeNJ23hvWsv0i9YN/NYaehzdugFoZK+zLcbFv0QwjCfluJUxi9HFSUA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.5.3.tgz",
+      "integrity": "sha512-KPD0Zp2t1Q1yYdND1jsqIEwNw26SufpQG+gWRGYTIAnEAA9W2VIeaMVvCDdD/j07cfBIF8EJ+yoxJFE3s+hvpQ==",
       "dependencies": {
         "ajv": "^8.11.0",
         "form-data": "^2.3.3",
@@ -11770,9 +11770,9 @@
       }
     },
     "@permanentorg/sdk": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.5.2.tgz",
-      "integrity": "sha512-i8iRHi4/mvsWu1NK1LJ5rQBQHXuTzb9yeNJ23hvWsv0i9YN/NYaehzdugFoZK+zLcbFv0QwjCfluJUxi9HFSUA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.5.3.tgz",
+      "integrity": "sha512-KPD0Zp2t1Q1yYdND1jsqIEwNw26SufpQG+gWRGYTIAnEAA9W2VIeaMVvCDdD/j07cfBIF8EJ+yoxJFE3s+hvpQ==",
       "requires": {
         "ajv": "^8.11.0",
         "form-data": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fusionauth/typescript-client": "^1.38.0",
-    "@permanentorg/sdk": "^0.5.2",
+    "@permanentorg/sdk": "^0.5.3",
     "@sentry/node": "^6.16.1",
     "dotenv": "^10.0.0",
     "logform": "^2.3.2",

--- a/src/classes/PermanentFileSystem.ts
+++ b/src/classes/PermanentFileSystem.ts
@@ -8,6 +8,7 @@ import {
   getArchiveFolders,
   getFolder,
   getArchiveRecord,
+  getAuthenticatedAccount,
 } from '@permanentorg/sdk';
 import {
   deduplicateFileEntries,
@@ -190,6 +191,13 @@ export class PermanentFileSystem {
   }
 
   public async deleteDirectory(requestedPath: string): Promise<void> {
+    const account = await getAuthenticatedAccount(
+      this.getClientConfiguration(),
+    );
+    if (!account.isSftpDeletionEnabled) {
+      throw new Error('You must enable SFTP deletion directly in your account settings.');
+    }
+
     if (isRootPath(requestedPath)) {
       throw new Error('You cannot delete the root level folder.');
     }

--- a/src/classes/PermanentFileSystem.ts
+++ b/src/classes/PermanentFileSystem.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import {
   createFolder,
   createArchiveRecord,
+  deleteFolder,
   getArchives,
   getArchiveFolders,
   getFolder,
@@ -185,6 +186,25 @@ export class PermanentFileSystem {
         name: childName,
       },
       parentFolder,
+    );
+  }
+
+  public async deleteDirectory(requestedPath: string): Promise<void> {
+    if (isRootPath(requestedPath)) {
+      throw new Error('You cannot delete the root level folder.');
+    }
+    if (isArchiveCataloguePath(requestedPath)) {
+      throw new Error('You cannot the archive catalogue.');
+    }
+    if (isArchivePath(requestedPath)) {
+      throw new Error('You cannot delete archives via SFTP.');
+    }
+
+    const folder = await this.loadFolder(requestedPath);
+
+    await deleteFolder(
+      this.getClientConfiguration(),
+      folder.id,
     );
   }
 

--- a/src/classes/SftpSessionHandler.ts
+++ b/src/classes/SftpSessionHandler.ts
@@ -541,15 +541,30 @@ export class SftpSessionHandler {
       'Request: SFTP remove directory path (SSH_FXP_RMDIR)',
       { reqId, directoryPath },
     );
-    logger.error('UNIMPLEMENTED Request: SFTP remove directory (SSH_FXP_RMDIR)');
-    logger.verbose(
-      'Response: Status (FAILURE)',
-      {
-        reqId,
-        code: SFTP_STATUS_CODE.FAILURE,
-      },
-    );
-    this.sftpConnection.status(reqId, SFTP_STATUS_CODE.FAILURE);
+
+    this.getCurrentPermanentFileSystem().deleteDirectory(directoryPath)
+      .then(() => {
+        logger.verbose(
+          'Response: Status (OK)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.OK,
+            path: directoryPath,
+          },
+        );
+        this.sftpConnection.status(reqId, SFTP_STATUS_CODE.OK);
+      })
+      .catch(() => {
+        logger.verbose(
+          'Response: Status (FAILURE)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.FAILURE,
+            path: directoryPath,
+          },
+        );
+        this.sftpConnection.status(reqId, SFTP_STATUS_CODE.FAILURE);
+      });
   }
 
   /**


### PR DESCRIPTION
This PR adds support for the RMDIR handler -- meaning a user could delete directories from permanent via SFTP.

NOTE: Until the permanent SDK actually populates this setting from real API responses the setting will always be "false" / this code won't actually run.