### PR TITLE
Support REMOVE

### DIFF
--- a/src/classes/PermanentFileSystem.ts
+++ b/src/classes/PermanentFileSystem.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import {
   createFolder,
   createArchiveRecord,
+  deleteArchiveRecord,
   deleteFolder,
   getArchives,
   getArchiveFolders,
@@ -236,6 +237,28 @@ export class PermanentFileSystem {
         fileSystemCompatibleName: archiveRecordName,
       },
       parentFolder,
+    );
+  }
+
+  public async deleteFile(requestedPath: string): Promise<void> {
+    const account = await getAuthenticatedAccount(
+      this.getClientConfiguration(),
+    );
+    if (!account.isSftpDeletionEnabled) {
+      throw new Error('You must enable SFTP deletion directly in your account settings.');
+    }
+
+    if (!isItemPath(requestedPath)) {
+      throw new Error('Invalid file path');
+    }
+
+    const archiveRecord = await this.loadArchiveRecord(
+      requestedPath,
+    );
+
+    await deleteArchiveRecord(
+      this.getClientConfiguration(),
+      archiveRecord.id,
     );
   }
 

--- a/src/classes/SftpSessionHandler.ts
+++ b/src/classes/SftpSessionHandler.ts
@@ -519,15 +519,30 @@ export class SftpSessionHandler {
       'Request: SFTP remove file (SSH_FXP_REMOVE)',
       { reqId, filePath },
     );
-    logger.error('UNIMPLEMENTED Request: SFTP remove file (SSH_FXP_REMOVE)');
-    logger.verbose(
-      'Response: Status (FAILURE)',
-      {
-        reqId,
-        code: SFTP_STATUS_CODE.FAILURE,
-      },
-    );
-    this.sftpConnection.status(reqId, SFTP_STATUS_CODE.FAILURE);
+
+    this.getCurrentPermanentFileSystem().deleteFile(filePath)
+      .then(() => {
+        logger.verbose(
+          'Response: Status (OK)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.OK,
+            path: filePath,
+          },
+        );
+        this.sftpConnection.status(reqId, SFTP_STATUS_CODE.OK);
+      })
+      .catch(() => {
+        logger.verbose(
+          'Response: Status (FAILURE)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.FAILURE,
+            path: filePath,
+          },
+        );
+        this.sftpConnection.status(reqId, SFTP_STATUS_CODE.FAILURE);
+      });
   }
 
   /**


### PR DESCRIPTION
This PR adds a handler for the `SSH_FXP_REMOVE` event.

Note, similarly to #120, the setting it checks is always falsy (due to the sdk implementation), but once the SDK is updated to use real data this code should work out of the box.

Resolves #25 