### PR TITLE
Use `create` name consistently

### DIFF
--- a/src/classes/PermanentFileSystem.ts
+++ b/src/classes/PermanentFileSystem.ts
@@ -169,7 +169,7 @@ export class PermanentFileSystem {
     return [];
   }
 
-  public async makeDirectory(requestedPath: string): Promise<Folder> {
+  public async createDirectory(requestedPath: string): Promise<Folder> {
     if (isRootPath(requestedPath)) {
       throw new Error('You cannot create new root level folders via SFTP.');
     }

--- a/src/classes/SftpSessionHandler.ts
+++ b/src/classes/SftpSessionHandler.ts
@@ -679,7 +679,7 @@ export class SftpSessionHandler {
         attrs,
       },
     );
-    this.getCurrentPermanentFileSystem().makeDirectory(dirPath)
+    this.getCurrentPermanentFileSystem().createDirectory(dirPath)
       .then(() => {
         logger.verbose('Response: Status (OK)', {
           reqId,


### PR DESCRIPTION
This PR updates the function previously known as `makeDirectory` to be consistent with the `createFile` method.

Resolves #122