### PR TITLE
Override node-fetch dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "node-fetch"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"
     schedule:


### PR DESCRIPTION
This PR does not allow dependabot to try to upgrade our `node-fetch` version to 3.x.