### PR TITLE
Correct local remote addresse in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@ SSH_HOST_KEY_PATH=${SSH_HOST_KEY_PATH}
 export NODE_TLS_REJECT_UNAUTHORIZED=0
 
 # The base url where the permanent API is hosted
-# e.g. http://local.permanet.org/api
+# e.g. http://local.permanent.org/api
 PERMANENT_API_BASE_PATH=${LOCAL_TEMPORARY_AUTH_TOKEN}
 
 # FusionAuth credentials


### PR DESCRIPTION
Copying and pasting the existing local remote from `.env.example` (`http://local.permanent.org/api`) could lead to some unwarranted debugging.