### PR TITLE
Support non-sequential writes

### DIFF
--- a/src/classes/SftpSessionHandler.ts
+++ b/src/classes/SftpSessionHandler.ts
@@ -256,6 +256,8 @@ export class SftpSessionHandler {
       temporaryFile.fd,
       data,
       0,
+      data.length,
+      offset,
       (err, written, buffer) => {
         if (err) {
           logger.verbose(


### PR DESCRIPTION
This PR fixes a bug where writes were always done in the order the commands were received (instead of writing to specific positions of the temporary file).

Resolves #207 