### PR TITLE
Update caches on item creation

### DIFF
--- a/src/classes/PermanentFileSystem.ts
+++ b/src/classes/PermanentFileSystem.ts
@@ -238,7 +238,7 @@ export class PermanentFileSystem {
       contentType: 'application/octet-stream',
       size,
     };
-    const archiveRecordfragment = {
+    const archiveRecordFragment = {
       displayName: archiveRecordName,
       fileSystemCompatibleName: archiveRecordName,
     };
@@ -246,14 +246,14 @@ export class PermanentFileSystem {
       await this.getClientConfiguration(),
       dataStream,
       fileFragment,
-      archiveRecordfragment,
+      archiveRecordFragment,
       parentFolder,
     );
     await createArchiveRecord(
       await this.getClientConfiguration(),
       s3Url,
       fileFragment,
-      archiveRecordfragment,
+      archiveRecordFragment,
       parentFolder,
     );
   }


### PR DESCRIPTION
This PR improves our caching logic so that we update our local caches to reflect the state of permanent upon archive record and archive folder creation.  In both cases this will prevent unnecessary call to the permanent back end.

I did verify locally that this lowers the number of calls to the API by 1 for each archive record being created.

Resolves #306 