### PR TITLE
Avoid unnecessary cache bypass

### DIFF
--- a/src/classes/PermanentFileSystem.ts
+++ b/src/classes/PermanentFileSystem.ts
@@ -147,11 +147,11 @@ export class PermanentFileSystem {
     const fileType = await this.getItemType(itemPath);
     switch (fileType) {
       case fs.constants.S_IFREG: {
-        const file = await this.loadFile(itemPath, true);
+        const file = await this.loadFile(itemPath);
         return generateAttributesForFile(file);
       }
       case fs.constants.S_IFDIR: {
-        const folder = await this.loadFolder(itemPath, true);
+        const folder = await this.loadFolder(itemPath);
         return generateAttributesForFolder(folder);
       }
       default:
@@ -170,10 +170,7 @@ export class PermanentFileSystem {
       return this.loadArchiveFoldersFileEntries(requestedPath);
     }
     if (isItemPath(requestedPath)) {
-      return this.loadFolderFileEntries(
-        requestedPath,
-        true,
-      );
+      return this.loadFolderFileEntries(requestedPath);
     }
     return [];
   }


### PR DESCRIPTION
This PR reverts part of a change made in https://github.com/PermanentOrg/sftp-service/commit/9fff82d39c6074164613ffbe8c799386e6607614.  I *believe* we no longer need this logic now that we have caches that get updated on file creation.  Note that this DOES mean if a file is created via a completely separate client at the same time as an SFTP upload it could result in confusing behavior / duplication (though one could argue if you upload the same file twice from two clients, it would be expected to appear twice).

Resolves #316
