### PR TITLE
Bypass cache busting when opening files for write

### DIFF
--- a/src/classes/PermanentFileSystem.ts
+++ b/src/classes/PermanentFileSystem.ts
@@ -344,6 +344,38 @@ export class PermanentFileSystem {
     }
   }
 
+  public folderPathExistsInCache(itemPath: string): boolean {
+    if (this.folderCache.has(itemPath)) {
+      return true;
+    }
+    const parentPath = path.dirname(itemPath);
+    const folderName = path.basename(itemPath);
+    const parentFolder = this.folderCache.get(parentPath);
+    if (!parentFolder) {
+      return false;
+    }
+    const foundFolder = parentFolder.folders.find(
+      (folder) => folder.fileSystemCompatibleName === folderName,
+    );
+    return foundFolder !== undefined;
+  }
+
+  public archiveRecordPathExistsInCache(itemPath: string): boolean {
+    if (this.archiveRecordCache.has(itemPath)) {
+      return true;
+    }
+    const parentPath = path.dirname(itemPath);
+    const archiveRecordName = path.basename(itemPath);
+    const parentFolder = this.folderCache.get(parentPath);
+    if (!parentFolder) {
+      return false;
+    }
+    const foundArchiveRecord = parentFolder.archiveRecords.find(
+      (folder) => folder.fileSystemCompatibleName === archiveRecordName,
+    );
+    return foundArchiveRecord !== undefined;
+  }
+
   private async loadArchiveRecord(
     requestedPath: string,
     overrideCache = false,


### PR DESCRIPTION
This PR updates our cache buster so that it is generally NOT invoked when files are being opened for the purposes of writing.

It does make sure that at least the parent folder has been loaded into the cache (though this would only need to happen once per folder, which seems appropriate)

Resolves #308