### PR TITLE
Remove wait for FileVOs to be populated

### DIFF
--- a/src/errors/FileStillProcessingError.ts
+++ b/src/errors/FileStillProcessingError.ts
@@ -1,1 +1,0 @@
-export class FileStillProcessingError extends Error {}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,4 +1,3 @@
-export * from './FileStillProcessingError';
 export * from './InvalidOperationForPathError';
 export * from './MissingTemporaryFileError';
 export * from './NotFoundError';


### PR DESCRIPTION
Now that the back end populates FileVOs in the response of `registerRecord` (see: https://github.com/PermanentOrg/back-end/pull/525), we don't have to wait an arbitrary amount of time for processing to happen on files. Remove the code that performs this wait, since its no longer necessary and it adds a theoretical 1 second delay per file in the upload process.