### PR TITLE
Pin @permanentorg/sdk to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fusionauth/typescript-client": "^1.48.0",
-    "@permanentorg/sdk": "^0.6.0",
+    "@permanentorg/sdk": "0.6.0",
     "@sentry/node": "^7.81.1",
     "dotenv": "^16.3.1",
     "logform": "^2.6.0",


### PR DESCRIPTION
An upcoming release of @permanentorg/sdk will be breaking, but will probably not be a major version upgrade (since we're still on an unstable v0). This commit pins the version of @permanentorg/sdk used here to 0.6.0 to avoid using the updated version before this repo is ready for it.