### PR TITLE
Dramatically improve upload performance

### DIFF
--- a/src/classes/PermanentFileSystem.ts
+++ b/src/classes/PermanentFileSystem.ts
@@ -444,7 +444,7 @@ export class PermanentFileSystem {
     );
 
     if (overrideParentCache && !targetFolder) {
-      throw new ResourceDoesNotExistError('The specified folder does not exist');
+      throw new ResourceDoesNotExistError(`The specified folder does not exist (${parentPath}/${folderName})`);
     }
     return targetFolder ?? this.findFolderInParentDirectory(
       parentPath,

--- a/src/classes/SftpSessionHandler.ts
+++ b/src/classes/SftpSessionHandler.ts
@@ -698,7 +698,6 @@ export class SftpSessionHandler {
     logger.debug(`Opening directory ${dirPath}:`, handle);
     const permanentFileSystem = this.getCurrentPermanentFileSystem();
     permanentFileSystem.loadDirectory(dirPath).then((fileEntries) => {
-      logger.debug('Contents:', fileEntries);
       const directoryResource = {
         virtualFilePath: dirPath,
         resourceType: ServerResourceType.Directory as const,

--- a/src/classes/SftpSessionHandler.ts
+++ b/src/classes/SftpSessionHandler.ts
@@ -797,12 +797,15 @@ export class SftpSessionHandler {
       this.sftpConnection.status(reqId, SFTP_STATUS_CODE.EOF);
       return;
     }
-    logger.verbose('Response: Name', { reqId, fileEntries });
+
+    const pageSize = 20;
+    const paginatedFileEntries = fileEntries.slice(cursor, cursor + pageSize);
     this.activeHandles.set(handle.toString(), {
       ...serverResource,
-      cursor: fileEntries.length,
+      cursor: cursor + pageSize,
     });
-    this.sftpConnection.name(reqId, fileEntries);
+    logger.verbose('Response: Name', { reqId, paginatedFileEntries });
+    this.sftpConnection.name(reqId, paginatedFileEntries);
   }
 
   /**


### PR DESCRIPTION
This PR removes some very expensive and fragile calls to the permanent API, which are no longer necessary thanks to the recent SDK upgrades which use Stela to populate folders with their children.

It also adds support for pagination in the SFTP response when loading folders, which should result in more scalable interactions with folders with lots of children.