### PR TITLE
Only return `NO_SUCH_FILE` if a resource truly wasn't found

### DIFF
--- a/src/classes/SftpSessionHandler.ts
+++ b/src/classes/SftpSessionHandler.ts
@@ -950,15 +950,30 @@ export class SftpSessionHandler {
       );
       this.sftpConnection.name(reqId, names);
     }).catch((err: unknown) => {
-      logger.debug(err);
-      logger.verbose(
-        'Response: Status (EOF)',
-        {
+      if (err instanceof ResourceDoesNotExistError) {
+        logger.verbose(
+          'Response: Status (NO_SUCH_FILE)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.NO_SUCH_FILE,
+          },
+        );
+        this.sftpConnection.status(reqId, SFTP_STATUS_CODE.NO_SUCH_FILE);
+      } else {
+        logger.debug(err);
+        logger.verbose(
+          'Response: Status (FAILURE)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.FAILURE,
+          },
+        );
+        this.sftpConnection.status(
           reqId,
-          code: SFTP_STATUS_CODE.NO_SUCH_FILE,
-        },
-      );
-      this.sftpConnection.status(reqId, SFTP_STATUS_CODE.NO_SUCH_FILE);
+          SFTP_STATUS_CODE.FAILURE,
+          'An error occurred when attempting to load this path from Permanent.org.',
+        );
+      }
     });
   }
 
@@ -1123,16 +1138,32 @@ export class SftpSessionHandler {
         attrs,
       );
     }).catch((err: unknown) => {
-      logger.debug(err);
-      logger.verbose(
-        'Response: Status (NO_SUCH_FILE)',
-        {
+      if (err instanceof ResourceDoesNotExistError) {
+        logger.verbose(
+          'Response: Status (NO_SUCH_FILE)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.NO_SUCH_FILE,
+            path: itemPath,
+          },
+        );
+        this.sftpConnection.status(reqId, SFTP_STATUS_CODE.NO_SUCH_FILE);
+      } else {
+        logger.debug(err);
+        logger.verbose(
+          'Response: Status (FAILURE)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.FAILURE,
+            path: itemPath,
+          },
+        );
+        this.sftpConnection.status(
           reqId,
-          code: SFTP_STATUS_CODE.NO_SUCH_FILE,
-          path: itemPath,
-        },
-      );
-      this.sftpConnection.status(reqId, SFTP_STATUS_CODE.NO_SUCH_FILE);
+          SFTP_STATUS_CODE.FAILURE,
+          'An error occurred when attempting to load this path from Permanent.org.',
+        );
+      }
     });
   }
 
@@ -1271,18 +1302,34 @@ export class SftpSessionHandler {
           Buffer.from(handle),
         );
       } catch (err) {
-        logger.verbose(
-          'Response: Status (NO_SUCH_FILE)',
-          {
+        if (err instanceof ResourceDoesNotExistError) {
+          logger.verbose(
+            'Response: Status (NO_SUCH_FILE)',
+            {
+              reqId,
+              code: SFTP_STATUS_CODE.NO_SUCH_FILE,
+            },
+          );
+          this.sftpConnection.status(
             reqId,
-            code: SFTP_STATUS_CODE.NO_SUCH_FILE,
-          },
-        );
-        this.sftpConnection.status(
-          reqId,
-          SFTP_STATUS_CODE.NO_SUCH_FILE,
-          'This path does not point to an existing resource, so it cannot be opened.',
-        );
+            SFTP_STATUS_CODE.NO_SUCH_FILE,
+            'This path does not point to an existing resource, so it cannot be opened.',
+          );
+        } else {
+          logger.debug(err);
+          logger.verbose(
+            'Response: Status (FAILURE)',
+            {
+              reqId,
+              code: SFTP_STATUS_CODE.FAILURE,
+            },
+          );
+          this.sftpConnection.status(
+            reqId,
+            SFTP_STATUS_CODE.FAILURE,
+            'An error occurred when attempting to load this path from Permanent.org.',
+          );
+        }
       }
     })().catch((err: unknown) => {
       logger.debug(err);


### PR DESCRIPTION
This PR updates our SftpSessionHandler to only return `NO_SUCH_FILE` to an sftp client if the PermanentFileSystem explicitly throws a `ResourceDoesNotExistError`.

Prior to this PR the SFTP service would incorrectly report that files and folders didn't exist if there were network or API errors when attempting to retrieve them.

This change at least gives SFTP clients a chance to potentially handle a thrown error more gracefully.

Another byproduct of this change is that we will no longer log "errors" when files don't exist (a file not existing is expected behavior).

Resolves #590