### PR TITLE
Retry on various 5xx errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@fusionauth/typescript-client": "^1.56.0",
-        "@permanentorg/sdk": "0.9.1",
+        "@permanentorg/sdk": "0.10.0",
         "@sentry/node": "^9.10.1",
         "dotenv": "^16.4.7",
         "logform": "^2.6.1",
@@ -3267,11 +3267,13 @@
       }
     },
     "node_modules/@permanentorg/sdk": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.9.1.tgz",
-      "integrity": "sha512-tOaPk3HXCCi4Id9odHM+c5ZSOX3gTZPGZbIPEjknwvnGw7DL8DCD4p13jYUXmOEX3fDkDEQfkoNfgLe20PaoEw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.10.0.tgz",
+      "integrity": "sha512-MnacLNnDlFzbcqx55BZUpjQYXh25gAfOr1UGmx3DdtmCWxdCZ66/hdTEO9QAdFGh5daJOvSyqOnP6kl7m6K9XQ==",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.0",
+        "fetch-retry": "^6.0.0",
         "form-data": "^4.0.0",
         "node-fetch": "^2.6.7"
       },
@@ -5669,6 +5671,12 @@
     },
     "node_modules/fecha": {
       "version": "4.2.1",
+      "license": "MIT"
+    },
+    "node_modules/fetch-retry": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
+      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fusionauth/typescript-client": "^1.56.0",
-    "@permanentorg/sdk": "0.9.1",
+    "@permanentorg/sdk": "0.10.0",
     "@sentry/node": "^9.10.1",
     "dotenv": "^16.4.7",
     "logform": "^2.6.1",

--- a/src/classes/PermanentFileSystem.ts
+++ b/src/classes/PermanentFileSystem.ts
@@ -380,6 +380,7 @@ export class PermanentFileSystem {
       bearerToken: authToken,
       baseUrl: process.env.PERMANENT_API_BASE_PATH,
       stelaBaseUrl: process.env.STELA_API_BASE_PATH,
+      retryOn: [500, 502, 503, 504],
     };
   }
 


### PR DESCRIPTION
This PR upgrades to the latest permanent SDK and enables the retryOn functionality for a few 5xx errors.

This won't prevent 504 responses but it may help resolve some of them without resorting to a FAILURE response to the SFTP client.

Resolves #592