### PR TITLE
Remove duplicate error type

### DIFF
--- a/src/classes/PermanentFileSystem.ts
+++ b/src/classes/PermanentFileSystem.ts
@@ -13,7 +13,6 @@ import {
 } from '@permanentorg/sdk';
 import {
   InvalidOperationForPathError,
-  NotFoundError,
   OperationNotAllowedError,
   ResourceDoesNotExistError,
 } from '../errors';
@@ -128,7 +127,7 @@ export class PermanentFileSystem {
         true,
       );
     }
-    throw new NotFoundError(`This path does not exist ${itemPath}`);
+    throw new ResourceDoesNotExistError(`This path does not exist ${itemPath}`);
   }
 
   public async getItemAttributes(itemPath: string): Promise<Attributes> {
@@ -153,7 +152,7 @@ export class PermanentFileSystem {
         return generateAttributesForFolder(folder);
       }
       default:
-        throw new NotFoundError('The specified path is neither a file nor a directory.');
+        throw new ResourceDoesNotExistError('The specified path is neither a file nor a directory.');
     }
   }
 

--- a/src/errors/NotFoundError.ts
+++ b/src/errors/NotFoundError.ts
@@ -1,1 +1,0 @@
-export class NotFoundError extends Error {}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,5 +1,4 @@
 export * from './InvalidOperationForPathError';
 export * from './MissingTemporaryFileError';
-export * from './NotFoundError';
 export * from './OperationNotAllowedError';
 export * from './ResourceDoesNotExistError';


### PR DESCRIPTION
This PR removes a duplicated error type (which was mistakenly not being handled properly when I added support for `Failure` vs `NotFound` SFTP status codes earlier this year)

Using only the handled error also resolves an issue where folder creation was failing due to that incorrect status code.

Resolves #607