### PR TITLE
Normalize filesystem language

### DIFF
--- a/src/classes/PermanentFileSystem.ts
+++ b/src/classes/PermanentFileSystem.ts
@@ -12,9 +12,9 @@ import {
   uploadFile,
 } from '@permanentorg/sdk';
 import {
+  FileSystemObjectNotFound,
   InvalidOperationForPathError,
   OperationNotAllowedError,
-  ResourceDoesNotExistError,
 } from '../errors';
 import {
   deduplicateFileEntries,
@@ -144,7 +144,7 @@ export class PermanentFileSystem {
         true,
       );
     }
-    throw new ResourceDoesNotExistError(`A file system object at the specified path could not be found: ${fileSystemPath}`);
+    throw new FileSystemObjectNotFound(`A file system object at the specified path could not be found: ${fileSystemPath}`);
   }
 
   public async getFileSystemObjectAttributes(fileSystemPath: string): Promise<Attributes> {
@@ -169,7 +169,8 @@ export class PermanentFileSystem {
         return generateAttributesForFolder(folder);
       }
       default:
-        throw new ResourceDoesNotExistError(`The specified path is neither a file nor a directory: ${fileSystemPath}`);
+        // Since fileType is not an enum we need a default case
+        throw new FileSystemObjectNotFound(`The specified path is neither a file nor a directory: ${fileSystemPath}`);
     }
   }
 
@@ -381,8 +382,8 @@ export class PermanentFileSystem {
     try {
       await this.loadArchive(fileSystemPath);
     } catch (error) {
-      if (error instanceof ResourceDoesNotExistError) {
-        throw new ResourceDoesNotExistError(`A resource at the specified path could not be found: ${fileSystemPath}`);
+      if (error instanceof FileSystemObjectNotFound) {
+        throw new FileSystemObjectNotFound(`A resource at the specified path could not be found: ${fileSystemPath}`);
       }
       throw error;
     }
@@ -398,8 +399,8 @@ export class PermanentFileSystem {
     try {
       await this.loadFolder(fileSystemPath);
     } catch (error) {
-      if (error instanceof ResourceDoesNotExistError) {
-        throw new ResourceDoesNotExistError(`A resource at the specified path could not be found ${fileSystemPath}`);
+      if (error instanceof FileSystemObjectNotFound) {
+        throw new FileSystemObjectNotFound(`A resource at the specified path could not be found ${fileSystemPath}`);
       }
       throw error;
     }
@@ -446,7 +447,7 @@ export class PermanentFileSystem {
     const archives = await this.loadArchives();
     const archive = archives.find((candidate) => candidate.slug === slug);
     if (archive === undefined) {
-      throw new ResourceDoesNotExistError('An archive with that slug could not be found');
+      throw new FileSystemObjectNotFound('An archive with that slug could not be found');
     }
     return archive;
   }
@@ -494,7 +495,7 @@ export class PermanentFileSystem {
     );
 
     if (overrideParentCache && !targetFolder) {
-      throw new ResourceDoesNotExistError(`The specified folder does not exist (${parentPath}/${folderName})`);
+      throw new FileSystemObjectNotFound(`The specified folder does not exist (${parentPath}/${folderName})`);
     }
     return targetFolder ?? this.findFolderInParentDirectory(
       parentPath,
@@ -520,7 +521,7 @@ export class PermanentFileSystem {
       return targetArchiveRecord;
     }
     if (overrideParentCache) {
-      throw new ResourceDoesNotExistError('The specified archive record does not exist');
+      throw new FileSystemObjectNotFound('The specified archive record does not exist');
     }
     // At this point we know that the lookup failed but ALSO that we may have been using a cached
     // version of the parent directory when checking for the child (`overrideParentCache` is false).

--- a/src/classes/SftpSessionHandler.ts
+++ b/src/classes/SftpSessionHandler.ts
@@ -938,7 +938,7 @@ export class SftpSessionHandler {
     const resolvedPath = path.resolve('/', relativePath);
 
     const permanentFileSystem = this.getCurrentPermanentFileSystem();
-    permanentFileSystem.getItemAttributes(resolvedPath).then((attrs) => {
+    permanentFileSystem.getFileSystemObjectAttributes(resolvedPath).then((attrs) => {
       const fileEntry = generateFileEntry(
         resolvedPath,
         attrs,
@@ -1124,7 +1124,7 @@ export class SftpSessionHandler {
 
   private genericStatHandler(reqId: number, itemPath: string): void {
     const permanentFileSystem = this.getCurrentPermanentFileSystem();
-    permanentFileSystem.getItemAttributes(itemPath).then((attrs) => {
+    permanentFileSystem.getFileSystemObjectAttributes(itemPath).then((attrs) => {
       logger.verbose(
         'Response: Attrs',
         {
@@ -1271,7 +1271,7 @@ export class SftpSessionHandler {
     const handle = generateHandle();
 
     (async () => {
-      const itemType = await permanentFileSystem.getItemType(filePath);
+      const itemType = await permanentFileSystem.getFileSystemObjectType(filePath);
       if (itemType === fs.constants.S_IFDIR) {
         this.sftpConnection.status(
           reqId,

--- a/src/classes/SftpSessionHandler.ts
+++ b/src/classes/SftpSessionHandler.ts
@@ -7,7 +7,7 @@ import { logger } from '../logger';
 import { generateFileEntry } from '../utils';
 import {
   MissingTemporaryFileError,
-  ResourceDoesNotExistError,
+  FileSystemObjectNotFound,
 } from '../errors';
 import { PermanentFileSystem } from './PermanentFileSystem';
 import { TemporaryFileManager } from './TemporaryFileManager';
@@ -950,7 +950,7 @@ export class SftpSessionHandler {
       );
       this.sftpConnection.name(reqId, names);
     }).catch((err: unknown) => {
-      if (err instanceof ResourceDoesNotExistError) {
+      if (err instanceof FileSystemObjectNotFound) {
         logger.verbose(
           'Response: Status (NO_SUCH_FILE)',
           {
@@ -1138,7 +1138,7 @@ export class SftpSessionHandler {
         attrs,
       );
     }).catch((err: unknown) => {
-      if (err instanceof ResourceDoesNotExistError) {
+      if (err instanceof FileSystemObjectNotFound) {
         logger.verbose(
           'Response: Status (NO_SUCH_FILE)',
           {
@@ -1245,7 +1245,7 @@ export class SftpSessionHandler {
         );
       });
     }).catch((err: unknown) => {
-      if (err instanceof ResourceDoesNotExistError) {
+      if (err instanceof FileSystemObjectNotFound) {
         logger.verbose(
           'Response: Status (FAILURE)',
           {
@@ -1302,7 +1302,7 @@ export class SftpSessionHandler {
           Buffer.from(handle),
         );
       } catch (err) {
-        if (err instanceof ResourceDoesNotExistError) {
+        if (err instanceof FileSystemObjectNotFound) {
           logger.verbose(
             'Response: Status (NO_SUCH_FILE)',
             {

--- a/src/errors/FileSystemObjectNotFound.ts
+++ b/src/errors/FileSystemObjectNotFound.ts
@@ -1,0 +1,2 @@
+// Thrown by the PermanentFileSystem when a referenced file or directory does not exist
+export class FileSystemObjectNotFound extends Error {}

--- a/src/errors/ResourceDoesNotExistError.ts
+++ b/src/errors/ResourceDoesNotExistError.ts
@@ -1,1 +1,0 @@
-export class ResourceDoesNotExistError extends Error {}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,4 +1,4 @@
+export * from './FileSystemObjectNotFound';
 export * from './InvalidOperationForPathError';
 export * from './MissingTemporaryFileError';
 export * from './OperationNotAllowedError';
-export * from './ResourceDoesNotExistError';


### PR DESCRIPTION
This PR improves our function and variable names to be more specific when we are referring to filesystem paths and filesystem objects.

This can seem verbose, but the clarity it provides is important because the permanent filesystem is bridging the gap between the API and a virtual filesystem.