### PR TITLE
Improve permission error name

### DIFF
--- a/src/classes/PermanentFileSystem.ts
+++ b/src/classes/PermanentFileSystem.ts
@@ -14,7 +14,7 @@ import {
 import {
   FileSystemObjectNotFound,
   InvalidOperationForPathError,
-  OperationNotAllowedError,
+  PermissionDeniedError,
 } from '../errors';
 import {
   deduplicateFileEntries,
@@ -192,13 +192,13 @@ export class PermanentFileSystem {
 
   public async createDirectory(fileSystemPath: string): Promise<void> {
     if (isRootPath(fileSystemPath)) {
-      throw new InvalidOperationForPathError('You cannot create new root level folders via SFTP.');
+      throw new PermissionDeniedError('You cannot create new root level folders via SFTP.');
     }
     if (isArchiveCataloguePath(fileSystemPath)) {
-      throw new InvalidOperationForPathError('You cannot create new archives via SFTP.');
+      throw new PermissionDeniedError('You cannot create new archives via SFTP.');
     }
     if (isArchivePath(fileSystemPath)) {
-      throw new InvalidOperationForPathError('You cannot create new folders at the root level of an archive via SFTP.');
+      throw new PermissionDeniedError('You cannot create new folders at the root level of an archive via SFTP.');
     }
     const parentPath = path.dirname(fileSystemPath);
     const childName = path.basename(fileSystemPath);
@@ -223,17 +223,17 @@ export class PermanentFileSystem {
       await this.getClientConfiguration(),
     );
     if (!account.isSftpDeletionEnabled) {
-      throw new OperationNotAllowedError('You must enable SFTP deletion directly in your account settings.');
+      throw new PermissionDeniedError('You must enable SFTP deletion directly in your account settings.');
     }
 
     if (isRootPath(fileSystemPath)) {
-      throw new InvalidOperationForPathError('You cannot delete the root level folder.');
+      throw new PermissionDeniedError('You cannot delete the root level folder.');
     }
     if (isArchiveCataloguePath(fileSystemPath)) {
-      throw new InvalidOperationForPathError('You cannot delete the archive catalogue.');
+      throw new PermissionDeniedError('You cannot delete the archive catalogue.');
     }
     if (isArchivePath(fileSystemPath)) {
-      throw new InvalidOperationForPathError('You cannot delete archives via SFTP.');
+      throw new PermissionDeniedError('You cannot delete archives via SFTP.');
     }
 
     const folder = await this.loadFolder(fileSystemPath);
@@ -291,7 +291,7 @@ export class PermanentFileSystem {
       await this.getClientConfiguration(),
     );
     if (!account.isSftpDeletionEnabled) {
-      throw new OperationNotAllowedError('You must enable SFTP deletion directly in your account settings.');
+      throw new PermissionDeniedError('You must enable SFTP deletion directly in your account settings.');
     }
 
     if (!isItemPath(fileSystemPath)) {

--- a/src/errors/InvalidOperationForPathError.ts
+++ b/src/errors/InvalidOperationForPathError.ts
@@ -1,1 +1,6 @@
+// This error is called internally within the PermanentFileSystem
+// when an permanent-scoped operation has been attempted on a path
+// that is not of the correct permanent object type.
+//
+// If it is seen it is an indication of a logical flow error.
 export class InvalidOperationForPathError extends Error {}

--- a/src/errors/OperationNotAllowedError.ts
+++ b/src/errors/OperationNotAllowedError.ts
@@ -1,1 +1,0 @@
-export class OperationNotAllowedError extends Error {}

--- a/src/errors/PermissionDeniedError.ts
+++ b/src/errors/PermissionDeniedError.ts
@@ -1,0 +1,1 @@
+export class PermissionDeniedError extends Error {}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,4 +1,4 @@
 export * from './FileSystemObjectNotFound';
 export * from './InvalidOperationForPathError';
 export * from './MissingTemporaryFileError';
-export * from './OperationNotAllowedError';
+export * from './PermissionDeniedError';


### PR DESCRIPTION
This PR fixes two issues:

1. It renames a confusingly named error (`OperationNotAllowedError`) and replaces it with a more explicitly permission-related error.

2. It fixes a mistaken use of `InvalidOperationForPathError` and clarifies what `InvalidOperationForPathError` is for