### PR TITLE
Group @babel dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,9 @@ updates:
       eslint:
         patterns:
           - '*eslint*'
+      babel:
+        patterns:
+          - '@babel/*'
 
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"


### PR DESCRIPTION
This PR adds a dependabot group for `@babel` dependencies so that we can review the related upgrades together.