### PR TITLE
Return `NO_SUCH_FILE` for `SSH_FXP_OPENDIR`

### DIFF
--- a/src/classes/SftpSessionHandler.ts
+++ b/src/classes/SftpSessionHandler.ts
@@ -715,21 +715,31 @@ export class SftpSessionHandler {
         Buffer.from(handle),
       );
     }).catch((err: unknown) => {
-      logger.warn(err);
-      logger.warn('Failed to load path', { reqId, dirPath });
-      logger.verbose(
-        'Response: Status (FAILURE)',
-        {
+      if (err instanceof FileSystemObjectNotFound) {
+        logger.verbose(
+          'Response: Status (NO_SUCH_FILE)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.NO_SUCH_FILE,
+          },
+        );
+        this.sftpConnection.status(reqId, SFTP_STATUS_CODE.NO_SUCH_FILE);
+      } else {
+        logger.debug(err);
+        logger.verbose(
+          'Response: Status (FAILURE)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.FAILURE,
+            path: dirPath,
+          },
+        );
+        this.sftpConnection.status(
           reqId,
-          code: SFTP_STATUS_CODE.FAILURE,
-          path: dirPath,
-        },
-      );
-      this.sftpConnection.status(
-        reqId,
-        SFTP_STATUS_CODE.FAILURE,
-        'An error occurred when attempting to load this directory from Permanent.org.',
-      );
+          SFTP_STATUS_CODE.FAILURE,
+          'An error occurred when attempting to load this directory from Permanent.org.',
+        );
+      }
     });
   }
 


### PR DESCRIPTION
This PR improves our `OPENDIR` handler to return `NO_SUCH_FILE` in the event that the requested directory (or directory path) doesn't exist.

Resolves #625