### PR TITLE
Consistently return `PERMISSION_DENIED` correctly

### DIFF
--- a/src/classes/SftpSessionHandler.ts
+++ b/src/classes/SftpSessionHandler.ts
@@ -1220,7 +1220,7 @@ export class SftpSessionHandler {
           'Response: Status (FAILURE)',
           {
             reqId,
-            code: SFTP_STATUS_CODE.PERMISSION_DENIED,
+            code: SFTP_STATUS_CODE.FAILURE,
             path: filePath,
           },
         );

--- a/src/classes/SftpSessionHandler.ts
+++ b/src/classes/SftpSessionHandler.ts
@@ -725,6 +725,19 @@ export class SftpSessionHandler {
           },
         );
         this.sftpConnection.status(reqId, SFTP_STATUS_CODE.NO_SUCH_FILE);
+      } else if (err instanceof PermissionDeniedError) {
+        logger.verbose(
+          'Response: Status (PERMISSION_DENIED)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.PERMISSION_DENIED,
+            path: dirPath,
+          },
+        );
+        this.sftpConnection.status(
+          reqId,
+          SFTP_STATUS_CODE.PERMISSION_DENIED,
+        );
       } else {
         logger.debug(err);
         logger.verbose(
@@ -883,6 +896,19 @@ export class SftpSessionHandler {
           },
         );
         this.sftpConnection.status(reqId, SFTP_STATUS_CODE.NO_SUCH_FILE);
+      } else if (err instanceof PermissionDeniedError) {
+        logger.verbose(
+          'Response: Status (PERMISSION_DENIED)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.PERMISSION_DENIED,
+            path: filePath,
+          },
+        );
+        this.sftpConnection.status(
+          reqId,
+          SFTP_STATUS_CODE.PERMISSION_DENIED,
+        );
       } else {
         logger.debug(err);
         logger.verbose(
@@ -935,6 +961,19 @@ export class SftpSessionHandler {
           },
         );
         this.sftpConnection.status(reqId, SFTP_STATUS_CODE.NO_SUCH_FILE);
+      } else if (err instanceof PermissionDeniedError) {
+        logger.verbose(
+          'Response: Status (PERMISSION_DENIED)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.PERMISSION_DENIED,
+            path: directoryPath,
+          },
+        );
+        this.sftpConnection.status(
+          reqId,
+          SFTP_STATUS_CODE.PERMISSION_DENIED,
+        );
       } else {
         logger.debug(err);
         logger.verbose(
@@ -989,6 +1028,19 @@ export class SftpSessionHandler {
           },
         );
         this.sftpConnection.status(reqId, SFTP_STATUS_CODE.NO_SUCH_FILE);
+      } else if (err instanceof PermissionDeniedError) {
+        logger.verbose(
+          'Response: Status (PERMISSION_DENIED)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.PERMISSION_DENIED,
+            path: relativePath,
+          },
+        );
+        this.sftpConnection.status(
+          reqId,
+          SFTP_STATUS_CODE.PERMISSION_DENIED,
+        );
       } else {
         logger.debug(err);
         logger.verbose(
@@ -1208,6 +1260,21 @@ export class SftpSessionHandler {
           },
         );
         this.sftpConnection.status(reqId, SFTP_STATUS_CODE.NO_SUCH_FILE);
+      } else if (err instanceof PermissionDeniedError) {
+        logger.verbose(
+          'Response: Status (PERMISSION_DENIED)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.PERMISSION_DENIED,
+            message: err.message,
+            path: itemPath,
+          },
+        );
+        this.sftpConnection.status(
+          reqId,
+          SFTP_STATUS_CODE.PERMISSION_DENIED,
+          err.message,
+        );
       } else {
         logger.debug(err);
         logger.verbose(
@@ -1255,16 +1322,16 @@ export class SftpSessionHandler {
       }
       if (permanentFileSystem.archiveRecordPathExistsInCache(filePath)) {
         logger.verbose(
-          'Response: Status (PERMISSION_DENIED)',
+          'Response: Status (FAILURE)',
           {
             reqId,
-            code: SFTP_STATUS_CODE.PERMISSION_DENIED,
+            code: SFTP_STATUS_CODE.FAILURE,
             path: filePath,
           },
         );
         this.sftpConnection.status(
           reqId,
-          SFTP_STATUS_CODE.PERMISSION_DENIED,
+          SFTP_STATUS_CODE.FAILURE,
           `An archive record already exists at ${filePath}.`,
         );
         return;
@@ -1318,6 +1385,19 @@ export class SftpSessionHandler {
           reqId,
           SFTP_STATUS_CODE.FAILURE,
           err.message,
+        );
+      } else if (err instanceof PermissionDeniedError) {
+        logger.verbose(
+          'Response: Status (PERMISSION_DENIED)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.PERMISSION_DENIED,
+            path: filePath,
+          },
+        );
+        this.sftpConnection.status(
+          reqId,
+          SFTP_STATUS_CODE.PERMISSION_DENIED,
         );
       } else {
         logger.debug(err);
@@ -1388,6 +1468,19 @@ export class SftpSessionHandler {
             reqId,
             SFTP_STATUS_CODE.NO_SUCH_FILE,
             'This path does not point to an existing resource, so it cannot be opened.',
+          );
+        } else if (err instanceof PermissionDeniedError) {
+          logger.verbose(
+            'Response: Status (PERMISSION_DENIED)',
+            {
+              reqId,
+              code: SFTP_STATUS_CODE.PERMISSION_DENIED,
+              path: filePath,
+            },
+          );
+          this.sftpConnection.status(
+            reqId,
+            SFTP_STATUS_CODE.PERMISSION_DENIED,
           );
         } else {
           logger.debug(err);

--- a/src/classes/SftpSessionHandler.ts
+++ b/src/classes/SftpSessionHandler.ts
@@ -874,20 +874,31 @@ export class SftpSessionHandler {
       );
       this.sftpConnection.status(reqId, SFTP_STATUS_CODE.OK);
     }).catch((err: unknown) => {
-      logger.debug(err);
-      logger.verbose(
-        'Response: Status (FAILURE)',
-        {
+      if (err instanceof FileSystemObjectNotFound) {
+        logger.verbose(
+          'Response: Status (NO_SUCH_FILE)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.NO_SUCH_FILE,
+          },
+        );
+        this.sftpConnection.status(reqId, SFTP_STATUS_CODE.NO_SUCH_FILE);
+      } else {
+        logger.debug(err);
+        logger.verbose(
+          'Response: Status (FAILURE)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.FAILURE,
+            path: filePath,
+          },
+        );
+        this.sftpConnection.status(
           reqId,
-          code: SFTP_STATUS_CODE.FAILURE,
-          path: filePath,
-        },
-      );
-      this.sftpConnection.status(
-        reqId,
-        SFTP_STATUS_CODE.FAILURE,
-        'An error occurred when attempting to delete this file on Permanent.org.',
-      );
+          SFTP_STATUS_CODE.FAILURE,
+          'An error occurred when attempting to delete this file on Permanent.org.',
+        );
+      }
     });
   }
 
@@ -915,20 +926,31 @@ export class SftpSessionHandler {
       );
       this.sftpConnection.status(reqId, SFTP_STATUS_CODE.OK);
     }).catch((err: unknown) => {
-      logger.debug(err);
-      logger.verbose(
-        'Response: Status (FAILURE)',
-        {
+      if (err instanceof FileSystemObjectNotFound) {
+        logger.verbose(
+          'Response: Status (NO_SUCH_FILE)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.NO_SUCH_FILE,
+          },
+        );
+        this.sftpConnection.status(reqId, SFTP_STATUS_CODE.NO_SUCH_FILE);
+      } else {
+        logger.debug(err);
+        logger.verbose(
+          'Response: Status (FAILURE)',
+          {
+            reqId,
+            code: SFTP_STATUS_CODE.FAILURE,
+            path: directoryPath,
+          },
+        );
+        this.sftpConnection.status(
           reqId,
-          code: SFTP_STATUS_CODE.FAILURE,
-          path: directoryPath,
-        },
-      );
-      this.sftpConnection.status(
-        reqId,
-        SFTP_STATUS_CODE.FAILURE,
-        'An error occurred when attempting to delete this directory on Permanent.org.',
-      );
+          SFTP_STATUS_CODE.FAILURE,
+          'An error occurred when attempting to delete this directory on Permanent.org.',
+        );
+      }
     });
   }
 


### PR DESCRIPTION
This PR adds more consistent use of `PERMISSION_DENIED` in our SFTP operation handlers.

It also includes a couple of additional instances where `FILE_NOT_FOUND` was being returned incorrectly; I included those in a separate commit (but this PR, since it was all part of the same "updated error processing" block)

Resolves #631