### PR TITLE
Retry on rate limit errors, and for longer

### DIFF
--- a/src/classes/PermanentFileSystem.ts
+++ b/src/classes/PermanentFileSystem.ts
@@ -487,7 +487,7 @@ export class PermanentFileSystem {
       bearerToken: authToken,
       baseUrl: process.env.PERMANENT_API_BASE_PATH,
       stelaBaseUrl: process.env.STELA_API_BASE_PATH,
-      retryOn: [500, 502, 503, 504],
+      retryOn: [429, 500, 502, 503, 504],
     };
   }
 


### PR DESCRIPTION
This PR improves our retry configuration to add retry for 429 errors.

It doesn't expand the number of retries or delay yet, since that will require an SDK update which has not yet been released.