### PR TITLE
Retry for longer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@fusionauth/typescript-client": "^1.57.0",
-        "@permanentorg/sdk": "0.10.0",
+        "@permanentorg/sdk": "0.10.1",
         "@sentry/node": "^9.24.0",
         "dotenv": "^16.5.0",
         "logform": "^2.6.1",
@@ -3303,9 +3303,9 @@
       }
     },
     "node_modules/@permanentorg/sdk": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.10.0.tgz",
-      "integrity": "sha512-MnacLNnDlFzbcqx55BZUpjQYXh25gAfOr1UGmx3DdtmCWxdCZ66/hdTEO9QAdFGh5daJOvSyqOnP6kl7m6K9XQ==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@permanentorg/sdk/-/sdk-0.10.1.tgz",
+      "integrity": "sha512-zoLOHOhClZtehRUeYtW69fAnwo7s1dge6hgSfAk1FrFhQK+Yi+IFYwAG1VYLAd8p7atZOSjoFM+MxkC71z9kZw==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fusionauth/typescript-client": "^1.57.0",
-    "@permanentorg/sdk": "0.10.0",
+    "@permanentorg/sdk": "0.10.1",
     "@sentry/node": "^9.24.0",
     "dotenv": "^16.5.0",
     "logform": "^2.6.1",

--- a/src/classes/PermanentFileSystem.ts
+++ b/src/classes/PermanentFileSystem.ts
@@ -488,6 +488,8 @@ export class PermanentFileSystem {
       baseUrl: process.env.PERMANENT_API_BASE_PATH,
       stelaBaseUrl: process.env.STELA_API_BASE_PATH,
       retryOn: [429, 500, 502, 503, 504],
+      retries: 5, // given our delay function, the total retry window with 5 retries is ~15 minutes
+      retryDelay: (attempt: number) => (2 ** attempt) * 15000,
     };
   }
 


### PR DESCRIPTION
This PR extends the duration that we retry on certain API call failures.  This is particularly important if we're getting rate limit errors.

Resolves #650