### PR TITLE
Remove `node_module` setup in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,25 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    outputs:
-      cache-key: ${{ steps.cache-key.outputs.key }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: .node-version
-      - id: cache-key
-        run: echo "key=node-modules-${{ hashFiles('package-lock.json') }}" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v5
-        id: cache
-        with:
-          path: node_modules
-          key: ${{ steps.cache-key.outputs.key }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci
-
   actionlint:
     runs-on: ubuntu-latest
     steps:
@@ -33,31 +14,25 @@ jobs:
       - uses: raven-actions/actionlint@v2
 
   lint:
-    needs: [setup]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
-      - uses: actions/cache@v5
-        with:
-          path: node_modules
-          key: ${{ needs.setup.outputs.cache-key }}
+          cache: npm
+      - run: npm ci
       - run: npm run lint
 
   test:
-    needs: [setup]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
-      - uses: actions/cache@v5
-        with:
-          path: node_modules
-          key: ${{ needs.setup.outputs.cache-key }}
+          cache: npm
+      - run: npm ci
       - run: npm run test:ci
       - uses: codecov/codecov-action@v5
         with:
@@ -66,15 +41,12 @@ jobs:
           fail_ci_if_error: true
 
   build:
-    needs: [setup]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
-      - uses: actions/cache@v5
-        with:
-          path: node_modules
-          key: ${{ needs.setup.outputs.cache-key }}
+          cache: npm
+      - run: npm ci
       - run: npm run build


### PR DESCRIPTION
This PR simplifies CI and removes an aggressive cache which could, in theory, cause us trouble down the line.

Resolves #793