### PR TITLE
Track major `uuid` versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
     cooldown:
       default-days: 7
     ignore:
-      - dependency-name: "uuid"
-        update-types: ["version-update:semver-major"]
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
       - dependency-name: "@typescript-eslint/eslint-plugin"


### PR DESCRIPTION
This PR removes the dependabot ignore for major uuid, now that we're using esm in this project.